### PR TITLE
ci(workflow): auto-link PRs to issues from branch names

### DIFF
--- a/.github/instructions/github-project-workflow.instructions.md
+++ b/.github/instructions/github-project-workflow.instructions.md
@@ -14,6 +14,7 @@ Use this repository in a strict task-first mode.
   - `Fixes #<id>`
   - `Resolves #<id>`
   - `Refs #<id>`
+- If you forget to add this explicitly, use branch names containing the issue number (for example `feature/123-chat-persistence`); CI will auto-append `Refs #123`.
 
 ## Parent/Sub-Issue Model
 

--- a/.github/workflows/pr-linked-issue.yml
+++ b/.github/workflows/pr-linked-issue.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   require-linked-issue:
@@ -13,19 +13,60 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Validate issue link in PR title/body
+      - name: Validate or auto-attach linked issue
         uses: actions/github-script@v7
         with:
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
             const title = context.payload.pull_request.title || "";
             const body = context.payload.pull_request.body || "";
+            const headRef = context.payload.pull_request.head?.ref || "";
             const text = `${title}\n${body}`;
 
-            const issueLinkPattern = /(close[sd]?|fix(e[sd])?|resolve[sd]?|ref(s|erences)?)\s+#\d+/i;
+            const issueLinkPattern = /(close[sd]?|fix(e[sd])?|resolve[sd]?|ref(s|erences)?)\s+#(\d+)/ig;
+            const existingMatches = [...text.matchAll(issueLinkPattern)];
 
-            if (!issueLinkPattern.test(text)) {
-              core.setFailed(
-                "This PR must link an issue using 'Closes #123', 'Fixes #123', 'Resolves #123', or 'Refs #123' in the title or description."
-              );
+            if (existingMatches.length > 0) {
+              core.info(`PR already linked to issue(s): ${existingMatches.map((m) => `#${m[4]}`).join(", ")}`);
+              return;
             }
+
+            // Auto-attach from branch names like `feature/123-...`, `bugfix/issue-45-...`, or `123-short-title`.
+            const branchIssueMatch = headRef.match(/(?:^|\/)(?:[a-z-]+\/)?(?:issue-)?(\d+)(?:[-_\/]|$)/i);
+
+            if (branchIssueMatch) {
+              const inferredIssueNumber = Number(branchIssueMatch[1]);
+
+              try {
+                await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: inferredIssueNumber,
+                });
+              } catch (error) {
+                core.setFailed(
+                  `Could not infer a valid issue from branch '${headRef}'. Issue #${inferredIssueNumber} was not found. Add 'Closes #<id>' or 'Refs #<id>' in the PR title/body.`
+                );
+                return;
+              }
+
+              const linkLine = `\n\nRefs #${inferredIssueNumber}`;
+              const updatedBody = `${body.trimEnd()}${linkLine}`.trimStart();
+
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pr.number,
+                body: updatedBody,
+              });
+
+              core.info(`Auto-attached issue link: Refs #${inferredIssueNumber}`);
+              return;
+            }
+
+            core.setFailed(
+              "This PR must link an issue using 'Closes #123', 'Fixes #123', 'Resolves #123', or 'Refs #123' in the title/body. Tip: branch names like 'feature/123-short-title' are auto-linked."
+            );
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -11,6 +11,11 @@ This repository uses GitHub automation for CI, pull request hygiene, dependency 
 - `.github/workflows/pr-title-conventional.yml`
   - Enforces Conventional Commit PR titles in the form `type(scope): description`.
 
+- `.github/workflows/pr-linked-issue.yml`
+  - Requires every PR to be linked to an issue with `Closes #<id>`, `Fixes #<id>`, `Resolves #<id>`, or `Refs #<id>`.
+  - If missing, auto-links from branch names that include the issue number (for example `feature/123-short-title` -> `Refs #123`).
+  - Fails the check when no explicit link exists and no issue number can be inferred.
+
 - `.github/workflows/bot-auto-approve.yml`
   - Auto-approves PRs only when label `bot-auto-approve` is present.
   - Uses `BOT_GITHUB_TOKEN`.


### PR DESCRIPTION
## Related issue
Closes #15
## What changed
- Added auto-link fallback in PR issue-link workflow using branch issue numbers
- Kept strict failure when no explicit or inferred issue link exists
- Updated project workflow instructions and automation docs