### PR TITLE
refactor(application): move garden advisor orchestration out of presentation

### DIFF
--- a/.github/instructions/github-project-workflow.instructions.md
+++ b/.github/instructions/github-project-workflow.instructions.md
@@ -56,3 +56,8 @@ A task is done only when all are true:
 - Related issue is closed
 - Parent issue progress is updated (automated workflow handles this for sub-issues)
 
+## Commit Automation Default
+
+- After Reviewer approval (`✅ All checks passed. Ready to merge.` or `🟡 Approved with inline fixes.`), run the Git Commit phase automatically unless the user explicitly asks to pause.
+- Git Commit phase must always include: `git status`, `git diff`, conventional commit with issue link, push branch, and PR creation/update.
+

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.74.0" />
     <PackageVersion Include="MQTTnet" Version="4.3.3.952" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />

--- a/HomeAssistant.Application/Chat/Abstractions/IChatAssistant.cs
+++ b/HomeAssistant.Application/Chat/Abstractions/IChatAssistant.cs
@@ -1,0 +1,23 @@
+﻿using HomeAssistant.Application.Chat.Contracts;
+
+namespace HomeAssistant.Application.Chat.Abstractions;
+
+/// <summary>Provides chat completions for helper-style conversational responses.</summary>
+public interface IChatAssistant
+{
+    /// <summary>Sends a contextual completion request to the configured LLM and returns its response text.</summary>
+    Task<string> GetReplyAsync(ChatCompletionRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Runs an agentic loop and may execute tool calls until a final response is produced.
+    /// </summary>
+    Task<AgenticChatResult> GetAgenticReplyAsync(
+        string systemPrompt,
+        IReadOnlyList<ChatHistoryMessage> history,
+        string userMessage,
+        IReadOnlyList<ChatToolDefinition> tools,
+        Func<ChatFunctionCall, CancellationToken, Task<string>> toolExecutor,
+        int maxIterations = 5,
+        CancellationToken ct = default);
+}
+

--- a/HomeAssistant.Application/Chat/Contracts/AgenticChatResult.cs
+++ b/HomeAssistant.Application/Chat/Contracts/AgenticChatResult.cs
@@ -1,0 +1,7 @@
+﻿namespace HomeAssistant.Application.Chat.Contracts;
+
+/// <summary>Result of an agentic chat turn.</summary>
+public sealed record AgenticChatResult(
+    string FinalReply,
+    IReadOnlyList<ChatFunctionCall> ExecutedCalls);
+

--- a/HomeAssistant.Application/Chat/Contracts/ChatCompletionRequest.cs
+++ b/HomeAssistant.Application/Chat/Contracts/ChatCompletionRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace HomeAssistant.Application.Chat.Contracts;
+
+/// <summary>Request for a context-aware LLM completion call.</summary>
+public sealed record ChatCompletionRequest(
+    string SystemPrompt,
+    string Prompt,
+    IReadOnlyList<ChatHistoryMessage> History,
+    string Capability);
+

--- a/HomeAssistant.Application/Chat/Contracts/ChatFunctionCall.cs
+++ b/HomeAssistant.Application/Chat/Contracts/ChatFunctionCall.cs
@@ -1,0 +1,5 @@
+﻿namespace HomeAssistant.Application.Chat.Contracts;
+
+/// <summary>A single function call the AI decided to make.</summary>
+public sealed record ChatFunctionCall(string FunctionName, string ArgumentsJson);
+

--- a/HomeAssistant.Application/Chat/Contracts/ChatHistoryMessage.cs
+++ b/HomeAssistant.Application/Chat/Contracts/ChatHistoryMessage.cs
@@ -1,0 +1,5 @@
+﻿namespace HomeAssistant.Application.Chat.Contracts;
+
+/// <summary>Represents one history message that is forwarded to the LLM.</summary>
+public sealed record ChatHistoryMessage(string Role, string Content);
+

--- a/HomeAssistant.Application/Chat/Contracts/ChatToolDefinition.cs
+++ b/HomeAssistant.Application/Chat/Contracts/ChatToolDefinition.cs
@@ -1,0 +1,9 @@
+﻿namespace HomeAssistant.Application.Chat.Contracts;
+
+/// <summary>Describes a single function the AI may call.</summary>
+public sealed record ChatToolDefinition(
+    string Name,
+    string Description,
+    IReadOnlyDictionary<string, ChatToolParameterSchema> Properties,
+    IReadOnlyList<string> Required);
+

--- a/HomeAssistant.Application/Chat/Contracts/ChatToolParameterSchema.cs
+++ b/HomeAssistant.Application/Chat/Contracts/ChatToolParameterSchema.cs
@@ -1,0 +1,8 @@
+﻿namespace HomeAssistant.Application.Chat.Contracts;
+
+/// <summary>JSON-Schema fragment for a single tool parameter.</summary>
+public sealed record ChatToolParameterSchema(
+    string Type,
+    string? Description = null,
+    IReadOnlyList<string>? Enum = null);
+

--- a/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdviceStateStore.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdviceStateStore.cs
@@ -1,0 +1,14 @@
+﻿using HomeAssistant.Application.GardenAdvisor.Contracts;
+
+namespace HomeAssistant.Application.GardenAdvisor.Abstractions;
+
+/// <summary>Stores the latest generated garden advice in-memory for read endpoints.</summary>
+public interface IGardenAdviceStateStore
+{
+    /// <summary>Gets the latest generated advice, if any.</summary>
+    GardenAdviceResponse? GetLatest();
+
+    /// <summary>Updates the latest generated advice snapshot.</summary>
+    void SetLatest(GardenAdviceResponse advice);
+}
+

--- a/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdvisorService.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdvisorService.cs
@@ -1,0 +1,11 @@
+﻿using HomeAssistant.Application.GardenAdvisor.Contracts;
+
+namespace HomeAssistant.Application.GardenAdvisor.Abstractions;
+
+/// <summary>Generates garden care advice from latest sensor and weather data.</summary>
+public interface IGardenAdvisorService
+{
+    /// <summary>Generates advice and optionally publishes MQTT updates.</summary>
+    Task<GardenAdviceResponse> GenerateAdviceAsync(bool publishToMqtt, CancellationToken ct = default);
+}
+

--- a/HomeAssistant.Application/GardenAdvisor/Abstractions/IPlantProfileProvider.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Abstractions/IPlantProfileProvider.cs
@@ -1,0 +1,11 @@
+﻿using HomeAssistant.Application.GardenAdvisor.Contracts;
+
+namespace HomeAssistant.Application.GardenAdvisor.Abstractions;
+
+/// <summary>Provides plant profile metadata for each monitored pot.</summary>
+public interface IPlantProfileProvider
+{
+    /// <summary>Returns all known pot profiles keyed by pot identifier.</summary>
+    IReadOnlyDictionary<Guid, PlantProfile> GetProfiles();
+}
+

--- a/HomeAssistant.Application/GardenAdvisor/Configuration/GardenAdvisorOptions.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Configuration/GardenAdvisorOptions.cs
@@ -1,0 +1,26 @@
+﻿namespace HomeAssistant.Application.GardenAdvisor.Configuration;
+
+/// <summary>Configuration options for garden advisory generation and scheduling.</summary>
+public sealed class GardenAdvisorOptions
+{
+    public string RegionName { get; init; } = "Unknown region";
+
+    public double Latitude { get; init; }
+
+    public double Longitude { get; init; }
+
+    public string Timezone { get; init; } = "auto";
+
+    public string AdviceSummaryTopic { get; init; } = "homeassistant/garden/advice/summary";
+
+    public string PotInsightTopicPrefix { get; init; } = "homeassistant/garden/pots";
+
+    public bool EnableScheduledAdvice { get; init; } = true;
+
+    public string PlannerResponseTopic { get; init; } = "homeassistant/garden/planner/response";
+
+    public string PlannerHistoryTopic { get; init; } = "homeassistant/garden/planner/history";
+
+    public int PlannerMaxIterations { get; init; } = 2;
+}
+

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/GardenAdviceResponse.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/GardenAdviceResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+
+/// <summary>Generated advisory summary for current pot readings and forecast context.</summary>
+public sealed record GardenAdviceResponse(
+    DateTimeOffset GeneratedAtUtc,
+    string Region,
+    GardenWeatherSnapshotResponse Weather,
+    IReadOnlyList<GardenPotInsightResponse> Pots,
+    string RecommendationSummary);
+

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/GardenPotInsightResponse.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/GardenPotInsightResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+
+/// <summary>Current insight snapshot for a single pot.</summary>
+public sealed record GardenPotInsightResponse(
+    Guid PotId,
+    int Position,
+    string PotLabel,
+    string PlantName,
+    string SeedName,
+    double SoilMoisture,
+    double TemperatureC,
+    string MoistureBand,
+    string TemperatureBand);
+

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/GardenWeatherSnapshotResponse.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/GardenWeatherSnapshotResponse.cs
@@ -1,0 +1,11 @@
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+
+/// <summary>Condensed weather snapshot used for garden decision support.</summary>
+public sealed record GardenWeatherSnapshotResponse(
+    double? TemperatureC,
+    double? WindSpeedKph,
+    double? WindGustsKph,
+    double? PrecipitationMm,
+    string Region,
+    string Timezone);
+

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/PlantProfile.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/PlantProfile.cs
@@ -1,0 +1,14 @@
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+
+/// <summary>Plant assignment and ideal condition band for a single pot.</summary>
+public sealed record PlantProfile(
+    Guid PotId,
+    int Position,
+    string PotLabel,
+    string PlantName,
+    string SeedName,
+    double IdealMoistureMin,
+    double IdealMoistureMax,
+    double IdealTempMinC,
+    double IdealTempMaxC);
+

--- a/HomeAssistant.Application/GardenAdvisor/Services/GardenAdviceStateStore.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Services/GardenAdviceStateStore.cs
@@ -1,0 +1,32 @@
+﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
+
+namespace HomeAssistant.Application.GardenAdvisor.Services;
+
+/// <summary>Thread-safe in-memory storage for the most recent garden advice payload.</summary>
+public sealed class GardenAdviceStateStore : IGardenAdviceStateStore
+{
+    private readonly object _sync = new();
+    private GardenAdviceResponse? _latest;
+
+    /// <inheritdoc />
+    public GardenAdviceResponse? GetLatest()
+    {
+        lock (_sync)
+        {
+            return _latest;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetLatest(GardenAdviceResponse advice)
+    {
+        ArgumentNullException.ThrowIfNull(advice);
+
+        lock (_sync)
+        {
+            _latest = advice;
+        }
+    }
+}
+

--- a/HomeAssistant.Application/GardenAdvisor/Services/GardenAdvisorService.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Services/GardenAdvisorService.cs
@@ -1,0 +1,227 @@
+﻿using System.Text;
+using System.Text.Json;
+using HomeAssistant.Application.Chat.Abstractions;
+using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Configuration;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.Messaging.Abstractions;
+using HomeAssistant.Application.Weather.Abstractions;
+using HomeAssistant.Application.Weather.Contracts;
+using HomeAssistant.Domain.SensorReadings.Abstractions;
+using HomeAssistant.Domain.SensorReadings.Entities;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HomeAssistant.Application.GardenAdvisor.Services;
+
+/// <summary>Combines live sensor data, weather context, and LLM reasoning into care recommendations.</summary>
+public sealed class GardenAdvisorService : IGardenAdvisorService
+{
+    private readonly ISensorProvider _sensorProvider;
+    private readonly IOpenMeteoForecastClient _forecastClient;
+    private readonly IChatAssistant _chatAssistant;
+    private readonly IMqttClient _mqttClient;
+    private readonly IPlantProfileProvider _plantProfileProvider;
+    private readonly IGardenAdviceStateStore _stateStore;
+    private readonly GardenAdvisorOptions _options;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<GardenAdvisorService> _logger;
+
+    /// <summary>Creates the advisor service.</summary>
+    public GardenAdvisorService(
+        ISensorProvider sensorProvider,
+        IOpenMeteoForecastClient forecastClient,
+        IChatAssistant chatAssistant,
+        IMqttClient mqttClient,
+        IPlantProfileProvider plantProfileProvider,
+        IGardenAdviceStateStore stateStore,
+        IOptions<GardenAdvisorOptions> options,
+        IConfiguration configuration,
+        ILogger<GardenAdvisorService> logger)
+    {
+        _sensorProvider = sensorProvider ?? throw new ArgumentNullException(nameof(sensorProvider));
+        _forecastClient = forecastClient ?? throw new ArgumentNullException(nameof(forecastClient));
+        _chatAssistant = chatAssistant ?? throw new ArgumentNullException(nameof(chatAssistant));
+        _mqttClient = mqttClient ?? throw new ArgumentNullException(nameof(mqttClient));
+        _plantProfileProvider = plantProfileProvider ?? throw new ArgumentNullException(nameof(plantProfileProvider));
+        _stateStore = stateStore ?? throw new ArgumentNullException(nameof(stateStore));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<GardenAdviceResponse> GenerateAdviceAsync(bool publishToMqtt, CancellationToken ct = default)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var profiles = _plantProfileProvider.GetProfiles();
+        var readings = await _sensorProvider.GetLatestReadingsAsync(ct);
+
+        var readingsByPot = readings
+            .GroupBy(static r => r.PotId)
+            .ToDictionary(static g => g.Key, static g => g.OrderByDescending(r => r.Timestamp).First());
+
+        var insights = profiles.Values
+            .OrderBy(static p => p.Position)
+            .Select(profile => BuildInsight(profile, readingsByPot.TryGetValue(profile.PotId, out var reading) ? reading : null))
+            .ToList();
+
+        var weather = await GetWeatherSnapshotAsync(ct);
+
+        var completion = new ChatCompletionRequest(
+            BuildSystemPrompt("garden-advisor"),
+            BuildPrompt(insights, weather),
+            [],
+            "garden-advisor");
+
+        var recommendation = await _chatAssistant.GetReplyAsync(completion, ct);
+
+        var response = new GardenAdviceResponse(
+            now,
+            _options.RegionName,
+            weather,
+            insights,
+            recommendation);
+
+        _stateStore.SetLatest(response);
+
+        if (publishToMqtt)
+        {
+            await PublishToMqttAsync(response, ct);
+        }
+
+        _logger.LogInformation("Generated garden advisory with {PotCount} pot insights.", insights.Count);
+        return response;
+    }
+
+    private string BuildSystemPrompt(string capability)
+    {
+        var defaultPrompt = _configuration["Assistant:SystemPrompt"]
+            ?? "You are HomeAssistant Helper for a Raspberry Pi garden automation system. Give practical, safe, concise guidance focused on plant care, seeding schedules, sensor interpretation, and home assistant troubleshooting.";
+
+        return $"{defaultPrompt} Capability mode: {capability}.";
+    }
+
+    private async Task<GardenWeatherSnapshotResponse> GetWeatherSnapshotAsync(CancellationToken ct)
+    {
+        try
+        {
+            var request = new OpenMeteoForecastRequest
+            {
+                Latitude = _options.Latitude,
+                Longitude = _options.Longitude,
+                Timezone = _options.Timezone,
+                ForecastDays = 2,
+                Current = ["temperature_2m", "wind_speed_10m", "wind_gusts_10m", "precipitation"],
+                Hourly = ["wind_gusts_10m", "temperature_2m", "precipitation_probability"],
+            };
+
+            var forecast = await _forecastClient.GetForecastAsync(request, ct);
+            var current = forecast.Current;
+
+            return new GardenWeatherSnapshotResponse(
+                ReadCurrentDouble(current, "temperature_2m"),
+                ReadCurrentDouble(current, "wind_speed_10m"),
+                ReadCurrentDouble(current, "wind_gusts_10m"),
+                ReadCurrentDouble(current, "precipitation"),
+                _options.RegionName,
+                forecast.Timezone ?? _options.Timezone);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch Open-Meteo weather snapshot; continuing with null weather values.");
+            return new GardenWeatherSnapshotResponse(null, null, null, null, _options.RegionName, _options.Timezone);
+        }
+    }
+
+    private static double? ReadCurrentDouble(IReadOnlyDictionary<string, JsonElement>? current, string key)
+    {
+        if (current is null || !current.TryGetValue(key, out var value))
+            return null;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetDouble(out var n) => n,
+            JsonValueKind.String when double.TryParse(value.GetString(), out var n) => n,
+            _ => null,
+        };
+    }
+
+    private static GardenPotInsightResponse BuildInsight(PlantProfile profile, SensorReading? reading)
+    {
+        var moisture = reading?.SoilMoisture ?? 0d;
+        var temp = reading?.TemperatureC ?? 0d;
+
+        return new GardenPotInsightResponse(
+            profile.PotId,
+            profile.Position,
+            profile.PotLabel,
+            profile.PlantName,
+            profile.SeedName,
+            moisture,
+            temp,
+            ResolveBand(moisture, profile.IdealMoistureMin, profile.IdealMoistureMax),
+            ResolveBand(temp, profile.IdealTempMinC, profile.IdealTempMaxC));
+    }
+
+    private static string ResolveBand(double value, double min, double max)
+        => value < min ? "Low" : value > max ? "High" : "Ideal";
+
+    private string BuildPrompt(IReadOnlyList<GardenPotInsightResponse> insights, GardenWeatherSnapshotResponse weather)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Generate actionable garden care guidance for the next 3 hours.");
+        sb.AppendLine("Constraints:");
+        sb.AppendLine("- Keep recommendations practical and safe.");
+        sb.AppendLine("- Mention wind gust mitigation when gusts are high.");
+        sb.AppendLine("- Consider region and current weather in every recommendation.");
+        sb.AppendLine("- Provide one concise bullet per pot plus a short global summary.");
+        sb.AppendLine();
+        sb.AppendLine($"Region: {_options.RegionName}");
+        sb.AppendLine($"Timezone: {weather.Timezone}");
+        sb.AppendLine($"Weather: temp={weather.TemperatureC?.ToString("0.0") ?? "n/a"}C, wind={weather.WindSpeedKph?.ToString("0.0") ?? "n/a"}kph, gusts={weather.WindGustsKph?.ToString("0.0") ?? "n/a"}kph, precipitation={weather.PrecipitationMm?.ToString("0.0") ?? "n/a"}mm.");
+        sb.AppendLine();
+        sb.AppendLine("Pot readings and target ranges:");
+
+        foreach (var pot in insights)
+        {
+            sb.AppendLine($"- {pot.PotLabel} ({pot.PlantName} / seed {pot.SeedName}): moisture={pot.SoilMoisture:0.0}% [{pot.MoistureBand}], temp={pot.TemperatureC:0.0}C [{pot.TemperatureBand}].");
+        }
+
+        return sb.ToString();
+    }
+
+    private async Task PublishToMqttAsync(GardenAdviceResponse advice, CancellationToken ct)
+    {
+        var summaryPayload = JsonSerializer.Serialize(new
+        {
+            generatedAtUtc = advice.GeneratedAtUtc.ToString("O"),
+            region = advice.Region,
+            summary = advice.RecommendationSummary,
+            weather = advice.Weather,
+        });
+
+        await _mqttClient.PublishAsync(_options.AdviceSummaryTopic, summaryPayload, retainFlag: true, ct);
+
+        foreach (var pot in advice.Pots)
+        {
+            var topic = $"{_options.PotInsightTopicPrefix}/{pot.Position}/insight";
+            var payload = JsonSerializer.Serialize(new
+            {
+                generatedAtUtc = advice.GeneratedAtUtc.ToString("O"),
+                potLabel = pot.PotLabel,
+                plantName = pot.PlantName,
+                seedName = pot.SeedName,
+                soilMoisture = pot.SoilMoisture,
+                temperatureC = pot.TemperatureC,
+                moistureBand = pot.MoistureBand,
+                temperatureBand = pot.TemperatureBand,
+            });
+
+            await _mqttClient.PublishAsync(topic, payload, retainFlag: true, ct);
+        }
+    }
+}
+

--- a/HomeAssistant.Application/GardenAdvisor/Services/PlantProfileProvider.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Services/PlantProfileProvider.cs
@@ -1,0 +1,23 @@
+﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
+
+namespace HomeAssistant.Application.GardenAdvisor.Services;
+
+/// <summary>Provides static seed and plant assignments for each monitored pot.</summary>
+public sealed class PlantProfileProvider : IPlantProfileProvider
+{
+    private static readonly IReadOnlyDictionary<Guid, PlantProfile> Profiles =
+        new Dictionary<Guid, PlantProfile>
+        {
+            [Guid.Parse("00000000-0000-0000-0000-000000000001")] = new(Guid.Parse("00000000-0000-0000-0000-000000000001"), 1, "Pot 1", "Tomato", "Moneymaker", 45, 70, 18, 26),
+            [Guid.Parse("00000000-0000-0000-0000-000000000002")] = new(Guid.Parse("00000000-0000-0000-0000-000000000002"), 2, "Pot 2", "Cucumber", "Marketmore", 50, 75, 20, 28),
+            [Guid.Parse("00000000-0000-0000-0000-000000000003")] = new(Guid.Parse("00000000-0000-0000-0000-000000000003"), 3, "Pot 3", "Basil", "Genovese", 40, 65, 18, 28),
+            [Guid.Parse("00000000-0000-0000-0000-000000000004")] = new(Guid.Parse("00000000-0000-0000-0000-000000000004"), 4, "Pot 4", "Carrot", "Nantes", 35, 60, 12, 24),
+            [Guid.Parse("00000000-0000-0000-0000-000000000005")] = new(Guid.Parse("00000000-0000-0000-0000-000000000005"), 5, "Pot 5", "Lettuce", "Little Gem", 45, 70, 10, 22),
+            [Guid.Parse("00000000-0000-0000-0000-000000000006")] = new(Guid.Parse("00000000-0000-0000-0000-000000000006"), 6, "Pot 6", "Pepper", "California Wonder", 40, 65, 18, 30),
+        };
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<Guid, PlantProfile> GetProfiles() => Profiles;
+}
+

--- a/HomeAssistant.Application/HomeAssistant.Application.csproj
+++ b/HomeAssistant.Application/HomeAssistant.Application.csproj
@@ -6,8 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 

--- a/HomeAssistant.Presentation/Chat/Endpoints/PostChatPrompt/PostChatPromptEndpoint.cs
+++ b/HomeAssistant.Presentation/Chat/Endpoints/PostChatPrompt/PostChatPromptEndpoint.cs
@@ -1,4 +1,6 @@
-﻿using HomeAssistant.Presentation.Chat.Services;
+﻿using HomeAssistant.Application.Chat.Abstractions;
+using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Presentation.Chat.Services;
 
 namespace HomeAssistant.Presentation.Chat.Endpoints.PostChatPrompt;
 
@@ -14,7 +16,7 @@ internal static class PostChatPromptEndpoint
                 string.Empty,
                 async Task<IResult>(
                     ChatRequest request,
-                    IChatAssistant assistant,
+                    HomeAssistant.Application.Chat.Abstractions.IChatAssistant assistant,
                     IConfiguration configuration,
                     CancellationToken ct) =>
                 {
@@ -23,7 +25,7 @@ internal static class PostChatPromptEndpoint
 
                     try
                     {
-                        var completion = new ChatCompletionRequest(
+                        var completion = new HomeAssistant.Application.Chat.Contracts.ChatCompletionRequest(
                             ChatSystemPromptBuilder.Build(configuration, "helper"),
                             request.Prompt,
                             [],

--- a/HomeAssistant.Presentation/Chat/Endpoints/PostChatSessionMessage/PostChatSessionMessageEndpoint.cs
+++ b/HomeAssistant.Presentation/Chat/Endpoints/PostChatSessionMessage/PostChatSessionMessageEndpoint.cs
@@ -1,4 +1,6 @@
-﻿using HomeAssistant.Domain.Assistant.Abstractions;
+﻿using HomeAssistant.Application.Chat.Abstractions;
+using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Domain.Assistant.Abstractions;
 using HomeAssistant.Domain.Assistant.Entities;
 using HomeAssistant.Presentation.Chat.Services;
 
@@ -18,7 +20,7 @@ internal static class PostChatSessionMessageEndpoint
                     Guid sessionId,
                     PostChatSessionMessageRequest request,
                     IChatSessionRepository sessions,
-                    IChatAssistant assistant,
+                    HomeAssistant.Application.Chat.Abstractions.IChatAssistant assistant,
                     IConfiguration configuration,
                     CancellationToken ct) =>
                 {
@@ -44,12 +46,12 @@ internal static class PostChatSessionMessageEndpoint
                     var maxHistory = int.TryParse(configuration["Assistant:MaxHistoryMessages"], out var parsedMax) ? parsedMax : 30;
                     var historyMessages = await sessions.GetMessagesAsync(sessionId, maxHistory, ct);
 
-                    var completion = new ChatCompletionRequest(
+                    var completion = new HomeAssistant.Application.Chat.Contracts.ChatCompletionRequest(
                         ChatSystemPromptBuilder.Build(configuration, session.Capability),
                         request.Prompt.Trim(),
                         historyMessages
                             .Where(m => m.Role is "user" or "assistant")
-                            .Select(m => new ChatHistoryMessage(m.Role, m.Content))
+                            .Select(m => new HomeAssistant.Application.Chat.Contracts.ChatHistoryMessage(m.Role, m.Content))
                             .ToList(),
                         session.Capability);
 

--- a/HomeAssistant.Presentation/Chat/Services/OllamaChatAssistant.cs
+++ b/HomeAssistant.Presentation/Chat/Services/OllamaChatAssistant.cs
@@ -1,11 +1,12 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
-using HomeAssistant.Presentation.Chat;
+using HomeAssistant.Application.Chat.Abstractions;
+using HomeAssistant.Application.Chat.Contracts;
 
 namespace HomeAssistant.Presentation.Chat.Services;
 
 /// <summary>Chat assistant backed by Ollama's <c>/api/generate</c> endpoint.</summary>
-public sealed class OllamaChatAssistant : IChatAssistant
+public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstractions.IChatAssistant
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
@@ -26,7 +27,7 @@ public sealed class OllamaChatAssistant : IChatAssistant
     }
 
     /// <inheritdoc/>
-    public async Task<string> GetReplyAsync(ChatCompletionRequest request, CancellationToken ct = default)
+    public async Task<string> GetReplyAsync(HomeAssistant.Application.Chat.Contracts.ChatCompletionRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (string.IsNullOrWhiteSpace(request.Prompt))
@@ -47,12 +48,12 @@ public sealed class OllamaChatAssistant : IChatAssistant
     }
 
     /// <inheritdoc/>
-    public async Task<AgenticChatResult> GetAgenticReplyAsync(
+    public async Task<HomeAssistant.Application.Chat.Contracts.AgenticChatResult> GetAgenticReplyAsync(
         string systemPrompt,
-        IReadOnlyList<ChatHistoryMessage> history,
+        IReadOnlyList<HomeAssistant.Application.Chat.Contracts.ChatHistoryMessage> history,
         string userMessage,
-        IReadOnlyList<ChatToolDefinition> tools,
-        Func<ChatFunctionCall, CancellationToken, Task<string>> toolExecutor,
+        IReadOnlyList<HomeAssistant.Application.Chat.Contracts.ChatToolDefinition> tools,
+        Func<HomeAssistant.Application.Chat.Contracts.ChatFunctionCall, CancellationToken, Task<string>> toolExecutor,
         int maxIterations = 5,
         CancellationToken ct = default)
     {
@@ -64,7 +65,7 @@ public sealed class OllamaChatAssistant : IChatAssistant
 
         var model = _configuration["Ollama:Model"] ?? "llama3.2:3b";
         var ollamaTools = tools.Select(MapToOllamaTool).ToList();
-        var executedCalls = new List<ChatFunctionCall>();
+        var executedCalls = new List<HomeAssistant.Application.Chat.Contracts.ChatFunctionCall>();
 
         // Build working message list: system + history + new user message
         var messages = new List<OllamaMessage> { new("system", systemPrompt) };
@@ -113,7 +114,7 @@ public sealed class OllamaChatAssistant : IChatAssistant
                         ? JsonSerializer.Serialize(tc.Function.Arguments, JsonOptions)
                         : "{}";
 
-                    var call = new ChatFunctionCall(funcName, argsJson);
+                    var call = new HomeAssistant.Application.Chat.Contracts.ChatFunctionCall(funcName, argsJson);
                     executedCalls.Add(call);
 
                     _logger.LogInformation("Executing tool call: {FunctionName}({Args}).", funcName, argsJson);
@@ -128,11 +129,11 @@ public sealed class OllamaChatAssistant : IChatAssistant
 
             // ── Text response — we're done ───────────────────────────────
             var text = result.Message.Content?.Trim() ?? string.Empty;
-            return new AgenticChatResult(text, executedCalls.AsReadOnly());
+            return new HomeAssistant.Application.Chat.Contracts.AgenticChatResult(text, executedCalls.AsReadOnly());
         }
 
         _logger.LogWarning("Agentic loop hit max iterations ({Max}); returning partial result.", maxIterations);
-        return new AgenticChatResult(
+        return new HomeAssistant.Application.Chat.Contracts.AgenticChatResult(
             "I've processed your request but ran out of reasoning steps. Please try again.",
             executedCalls.AsReadOnly());
     }
@@ -170,7 +171,7 @@ public sealed class OllamaChatAssistant : IChatAssistant
 
     // ── Mapping helpers ───────────────────────────────────────────────────
 
-    private static OllamaTool MapToOllamaTool(ChatToolDefinition def)
+    private static OllamaTool MapToOllamaTool(HomeAssistant.Application.Chat.Contracts.ChatToolDefinition def)
     {
         var props = def.Properties.ToDictionary(
             kv => kv.Key,

--- a/HomeAssistant.Presentation/Configuration/ExternalClientsConfiguration.cs
+++ b/HomeAssistant.Presentation/Configuration/ExternalClientsConfiguration.cs
@@ -1,5 +1,6 @@
-﻿using HomeAssistant.Presentation.Chat;
+﻿using HomeAssistant.Application.Chat.Abstractions;
 using HomeAssistant.Presentation.Chat.Services;
+using Microsoft.Extensions.Logging;
 
 namespace HomeAssistant.Presentation.Configuration;
 
@@ -14,13 +15,18 @@ internal static class ExternalClientsConfiguration
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        services.AddHttpClient<IChatAssistant, OllamaChatAssistant>((sp, client) =>
+        services.AddHttpClient("ollama-chat", client =>
         {
-            var config = sp.GetRequiredService<IConfiguration>();
-            var baseUrl = config["Ollama:BaseUrl"] ?? "http://localhost:11434/";
+            var baseUrl = configuration["Ollama:BaseUrl"] ?? "http://localhost:11434/";
             client.BaseAddress = new Uri(baseUrl, UriKind.Absolute);
             client.Timeout = TimeSpan.FromSeconds(60);
         });
+
+        services.AddScoped<IChatAssistant>(sp =>
+            new OllamaChatAssistant(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient("ollama-chat"),
+                sp.GetRequiredService<IConfiguration>(),
+                sp.GetRequiredService<ILogger<OllamaChatAssistant>>()));
 
         return services;
     }

--- a/HomeAssistant.Presentation/Configuration/GardenAdvisorConfiguration.cs
+++ b/HomeAssistant.Presentation/Configuration/GardenAdvisorConfiguration.cs
@@ -1,6 +1,7 @@
-﻿using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
+﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Configuration;
+using HomeAssistant.Application.GardenAdvisor.Services;
 using HomeAssistant.Presentation.GardenAdvisor.BackgroundServices;
-using HomeAssistant.Presentation.GardenAdvisor.Configuration;
 using HomeAssistant.Presentation.GardenAdvisor.Services;
 
 namespace HomeAssistant.Presentation.Configuration;
@@ -20,15 +21,15 @@ internal static class GardenAdvisorConfiguration
         services.Configure<GardenAdvisorOptions>(configuration.GetSection("GardenAdvisor"));
 
         // Singleton stores and providers
-        services.AddSingleton<IPlantProfileProvider, PlantProfileProvider>();
-        services.AddSingleton<IGardenAdviceStateStore, GardenAdviceStateStore>();
-        services.AddSingleton<IGardenPlannerHistoryStore, GardenPlannerHistoryStore>();
+        services.AddSingleton<IPlantProfileProvider, HomeAssistant.Application.GardenAdvisor.Services.PlantProfileProvider>();
+        services.AddSingleton<IGardenAdviceStateStore, HomeAssistant.Application.GardenAdvisor.Services.GardenAdviceStateStore>();
+        services.AddSingleton<HomeAssistant.Presentation.GardenAdvisor.Abstractions.IGardenPlannerHistoryStore, GardenPlannerHistoryStore>();
 
         // Scoped services
-        services.AddScoped<IGardenAdvisorService, GardenAdvisorService>();
+        services.AddScoped<IGardenAdvisorService, HomeAssistant.Application.GardenAdvisor.Services.GardenAdvisorService>();
         services.AddScoped<HomeAssistant.Presentation.GardenAdvisor.Services.IHomeAssistantAreaProvider,
             HomeAssistant.Presentation.GardenAdvisor.Services.HomeAssistantAreaProvider>();
-        services.AddScoped<IGardenPlannerService, GardenPlannerService>();
+        services.AddScoped<HomeAssistant.Presentation.GardenAdvisor.Abstractions.IGardenPlannerService, GardenPlannerService>();
 
         // Background services
         services.AddHostedService<GardenAdviceScheduleBackgroundService>();

--- a/HomeAssistant.Presentation/GardenAdvisor/Abstractions/IGardenPlannerFunctionService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Abstractions/IGardenPlannerFunctionService.cs
@@ -36,10 +36,10 @@ public interface IGardenPlannerFunctionService
     Task<IReadOnlyList<HarvestReadinessResponse>> GetHarvestReadinessAsync(HarvestReadinessFunctionRequest request, CancellationToken ct = default);
 
     /// <summary>Returns the latest in-memory garden advice, if available.</summary>
-    GardenAdviceResponse? GetLatestAdvice();
+    HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse? GetLatestAdvice();
 
     /// <summary>Generates fresh garden advice and optionally publishes MQTT updates.</summary>
-    Task<GardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default);
+    Task<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default);
 
     /// <summary>Clears the in-memory planner chat history.</summary>
     string ClearPlannerHistory();

--- a/HomeAssistant.Presentation/GardenAdvisor/BackgroundServices/GardenAdviceScheduleBackgroundService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/BackgroundServices/GardenAdviceScheduleBackgroundService.cs
@@ -1,5 +1,5 @@
-﻿using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
-using HomeAssistant.Presentation.GardenAdvisor.Configuration;
+﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.BackgroundServices;

--- a/HomeAssistant.Presentation/GardenAdvisor/Endpoints/GetLatestGardenAdvice/GetLatestGardenAdviceEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Endpoints/GetLatestGardenAdvice/GetLatestGardenAdviceEndpoint.cs
@@ -1,5 +1,5 @@
-﻿using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
-using HomeAssistant.Presentation.GardenAdvisor.Contracts;
+﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.GetLatestGardenAdvice;
 

--- a/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PlannerFunctions/GardenPlannerFunctionEndpoints.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PlannerFunctions/GardenPlannerFunctionEndpoints.cs
@@ -72,14 +72,14 @@ public static class GardenPlannerFunctionEndpoints
         group.MapGet("/advice/latest", GetLatestAdvice)
             .WithName("PlannerFunctionGetLatestAdvice")
             .WithOpenApi()
-            .Produces<GardenAdviceResponse>(StatusCodes.Status200OK)
+            .Produces<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
 
         group.MapPost("/advice/generate", GenerateAdvice)
             .WithName("PlannerFunctionGenerateAdvice")
             .WithOpenApi()
             .Accepts<GeneratePlannerAdviceFunctionRequest>("application/json")
-            .Produces<GardenAdviceResponse>(StatusCodes.Status200OK);
+            .Produces<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>(StatusCodes.Status200OK);
 
         group.MapPost("/history/clear", ClearHistory)
             .WithName("PlannerFunctionClearHistory")
@@ -191,7 +191,7 @@ public static class GardenPlannerFunctionEndpoints
         return TypedResults.Ok(await service.GetHarvestReadinessAsync(new HarvestReadinessFunctionRequest(filterByStatus), ct));
     }
 
-    private static Results<Ok<GardenAdviceResponse>, NotFound> GetLatestAdvice(IGardenPlannerFunctionService service)
+    private static Results<Ok<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>, NotFound> GetLatestAdvice(IGardenPlannerFunctionService service)
     {
         ArgumentNullException.ThrowIfNull(service);
 
@@ -199,7 +199,7 @@ public static class GardenPlannerFunctionEndpoints
         return latest is null ? TypedResults.NotFound() : TypedResults.Ok(latest);
     }
 
-    private static async Task<Ok<GardenAdviceResponse>> GenerateAdvice(
+    private static async Task<Ok<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>> GenerateAdvice(
         GeneratePlannerAdviceFunctionRequest? request,
         IGardenPlannerFunctionService service,
         CancellationToken ct)

--- a/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PostGenerateGardenAdvice/PostGenerateGardenAdviceEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PostGenerateGardenAdvice/PostGenerateGardenAdviceEndpoint.cs
@@ -1,4 +1,5 @@
-﻿using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
+﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
 using HomeAssistant.Presentation.GardenAdvisor.Contracts;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGenerateGardenAdvice;
@@ -34,7 +35,7 @@ internal static class PostGenerateGardenAdviceEndpoint
             .WithName("PostGenerateGardenAdvice")
             .WithSummary("Generates a new advice summary from latest sensor and weather data")
             .WithDescription("Triggers Ollama to evaluate the latest pot state with weather context and optional MQTT publication.")
-            .Produces<GardenAdviceResponse>()
+            .Produces<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>()
             .ProducesProblem(StatusCodes.Status502BadGateway);
     }
 }

--- a/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerFunctionService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerFunctionService.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
 using HomeAssistant.Application.Dispatching;
+using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
 using HomeAssistant.Application.PotConfigurations.Commands;
 using HomeAssistant.Application.PotConfigurations.DTOs;
 using HomeAssistant.Application.PotConfigurations.Queries;
@@ -34,8 +36,8 @@ public sealed class GardenPlannerFunctionService : IGardenPlannerFunctionService
     private readonly IQueryHandler<GetRoomSummaryQuery, RoomSummaryDto> _roomSummaryHandler;
     private readonly IQueryHandler<GetHarvestReadinessQuery, IReadOnlyList<HarvestReadinessDto>> _harvestReadinessHandler;
     private readonly IHomeAssistantAreaProvider _areaProvider;
-    private readonly IGardenAdviceStateStore _adviceStateStore;
-    private readonly IGardenAdvisorService _gardenAdvisorService;
+    private readonly HomeAssistant.Application.GardenAdvisor.Abstractions.IGardenAdviceStateStore _adviceStateStore;
+    private readonly HomeAssistant.Application.GardenAdvisor.Abstractions.IGardenAdvisorService _gardenAdvisorService;
     private readonly IGardenPlannerHistoryStore _historyStore;
     private readonly ILogger<GardenPlannerFunctionService> _logger;
 
@@ -48,8 +50,8 @@ public sealed class GardenPlannerFunctionService : IGardenPlannerFunctionService
         IQueryHandler<GetRoomSummaryQuery, RoomSummaryDto> roomSummaryHandler,
         IQueryHandler<GetHarvestReadinessQuery, IReadOnlyList<HarvestReadinessDto>> harvestReadinessHandler,
         IHomeAssistantAreaProvider areaProvider,
-        IGardenAdviceStateStore adviceStateStore,
-        IGardenAdvisorService gardenAdvisorService,
+        HomeAssistant.Application.GardenAdvisor.Abstractions.IGardenAdviceStateStore adviceStateStore,
+        HomeAssistant.Application.GardenAdvisor.Abstractions.IGardenAdvisorService gardenAdvisorService,
         IGardenPlannerHistoryStore historyStore,
         ILogger<GardenPlannerFunctionService> logger)
     {
@@ -223,10 +225,10 @@ public sealed class GardenPlannerFunctionService : IGardenPlannerFunctionService
     }
 
     /// <inheritdoc/>
-    public GardenAdviceResponse? GetLatestAdvice() => _adviceStateStore.GetLatest();
+    public HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse? GetLatestAdvice() => _adviceStateStore.GetLatest();
 
     /// <inheritdoc/>
-    public Task<GardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default)
+    public Task<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         return _gardenAdvisorService.GenerateAdviceAsync(request.PublishToMqtt, ct);

--- a/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerService.cs
@@ -1,11 +1,14 @@
 ﻿using System.Diagnostics.Metrics;
 using System.Text;
 using System.Text.Json;
+using HomeAssistant.Application.Chat.Abstractions;
+using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Configuration;
+using HomeAssistant.Application.GardenAdvisor.Contracts;
 using HomeAssistant.Application.Messaging.Abstractions;
 using HomeAssistant.Domain.PotConfigurations.Abstractions;
-using HomeAssistant.Presentation.Chat;
 using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
-using HomeAssistant.Presentation.GardenAdvisor.Configuration;
 using HomeAssistant.Presentation.GardenAdvisor.Contracts;
 using Microsoft.Extensions.Options;
 
@@ -291,12 +294,12 @@ public sealed class GardenPlannerService : IGardenPlannerService
             ? "No harvest-readiness items were found."
             : string.Join(" ", items.Select(i => $"{i.PlantName}/{i.SeedName} in pot {i.PotId}: score {i.ReadinessScore}, category {i.ReadinessCategory}."));
 
-    private static string FormatLatestAdvice(GardenAdviceResponse? advice)
+    private static string FormatLatestAdvice(HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse? advice)
         => advice is null
             ? "No garden advice has been generated yet."
             : $"Latest advice ({advice.GeneratedAtUtc:O}): {advice.RecommendationSummary}";
 
-    private static string FormatAdvice(GardenAdviceResponse advice)
+    private static string FormatAdvice(HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse advice)
         => $"Generated advice ({advice.GeneratedAtUtc:O}): {advice.RecommendationSummary}";
 
     private static string FormatActionDescription(ChatFunctionCall call)


### PR DESCRIPTION
## Related issue
Closes #8
## What changed
- Moved GardenAdvisor orchestration contracts/abstractions/services into HomeAssistant.Application
- Rewired Presentation endpoints/services to consume Application-layer chat and advisor abstractions
- Updated DI wiring and central package versions to support new Application-layer services
- Added workflow instruction to auto-run Git Commit phase after reviewer approval unless user opts out
## Validation
- dotnet build HomeAssistant.sln succeeds