### PR TITLE
docs(workflow): require project assignment for new issues

### DIFF
--- a/.github/instructions/github-project-workflow.instructions.md
+++ b/.github/instructions/github-project-workflow.instructions.md
@@ -9,6 +9,7 @@ Use this repository in a strict task-first mode.
 ## Core Rule
 
 - Do not implement non-trivial changes unless there is an existing GitHub issue/task for the work.
+- Any newly created issue or sub-issue must be added to the repository GitHub Project (`Garden AI`) immediately after creation.
 - Every implementation PR must link an issue using one of:
   - `Closes #<id>`
   - `Fixes #<id>`


### PR DESCRIPTION
## Related issue
Closes #40
## What changed
- Updated .github/instructions/github-project-workflow.instructions.md
- Added an explicit rule that newly created issues and sub-issues must be added to the Garden AI GitHub Project immediately after creation
## Notes
- Documentation-only workflow change