### PR TITLE
refactor(application): co-locate chat and advisor contracts by feature

### DIFF
--- a/HomeAssistant.Application/Chat/Abstractions/IChatAssistant.cs
+++ b/HomeAssistant.Application/Chat/Abstractions/IChatAssistant.cs
@@ -1,4 +1,5 @@
-﻿using HomeAssistant.Application.Chat.Contracts;
+﻿using HomeAssistant.Application.Chat.Contracts.Agentic;
+using HomeAssistant.Application.Chat.Contracts.Completions;
 
 namespace HomeAssistant.Application.Chat.Abstractions;
 

--- a/HomeAssistant.Application/Chat/Contracts/Agentic/AgenticChatResult.cs
+++ b/HomeAssistant.Application/Chat/Contracts/Agentic/AgenticChatResult.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.Chat.Contracts;
+﻿namespace HomeAssistant.Application.Chat.Contracts.Agentic;
 
 /// <summary>Result of an agentic chat turn.</summary>
 public sealed record AgenticChatResult(

--- a/HomeAssistant.Application/Chat/Contracts/Agentic/ChatFunctionCall.cs
+++ b/HomeAssistant.Application/Chat/Contracts/Agentic/ChatFunctionCall.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.Chat.Contracts;
+﻿namespace HomeAssistant.Application.Chat.Contracts.Agentic;
 
 /// <summary>A single function call the AI decided to make.</summary>
 public sealed record ChatFunctionCall(string FunctionName, string ArgumentsJson);

--- a/HomeAssistant.Application/Chat/Contracts/Agentic/ChatHistoryMessage.cs
+++ b/HomeAssistant.Application/Chat/Contracts/Agentic/ChatHistoryMessage.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.Chat.Contracts;
+﻿namespace HomeAssistant.Application.Chat.Contracts.Agentic;
 
 /// <summary>Represents one history message that is forwarded to the LLM.</summary>
 public sealed record ChatHistoryMessage(string Role, string Content);

--- a/HomeAssistant.Application/Chat/Contracts/Agentic/ChatToolDefinition.cs
+++ b/HomeAssistant.Application/Chat/Contracts/Agentic/ChatToolDefinition.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.Chat.Contracts;
+﻿namespace HomeAssistant.Application.Chat.Contracts.Agentic;
 
 /// <summary>Describes a single function the AI may call.</summary>
 public sealed record ChatToolDefinition(

--- a/HomeAssistant.Application/Chat/Contracts/Agentic/ChatToolParameterSchema.cs
+++ b/HomeAssistant.Application/Chat/Contracts/Agentic/ChatToolParameterSchema.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.Chat.Contracts;
+﻿namespace HomeAssistant.Application.Chat.Contracts.Agentic;
 
 /// <summary>JSON-Schema fragment for a single tool parameter.</summary>
 public sealed record ChatToolParameterSchema(

--- a/HomeAssistant.Application/Chat/Contracts/Completions/ChatCompletionRequest.cs
+++ b/HomeAssistant.Application/Chat/Contracts/Completions/ChatCompletionRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace HomeAssistant.Application.Chat.Contracts;
+﻿using HomeAssistant.Application.Chat.Contracts.Agentic;
+
+namespace HomeAssistant.Application.Chat.Contracts.Completions;
 
 /// <summary>Request for a context-aware LLM completion call.</summary>
 public sealed record ChatCompletionRequest(

--- a/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdviceStateStore.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdviceStateStore.cs
@@ -1,4 +1,4 @@
-﻿using HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 namespace HomeAssistant.Application.GardenAdvisor.Abstractions;
 

--- a/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdvisorService.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Abstractions/IGardenAdvisorService.cs
@@ -1,4 +1,4 @@
-﻿using HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 namespace HomeAssistant.Application.GardenAdvisor.Abstractions;
 

--- a/HomeAssistant.Application/GardenAdvisor/Abstractions/IPlantProfileProvider.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Abstractions/IPlantProfileProvider.cs
@@ -1,4 +1,4 @@
-﻿using HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿using HomeAssistant.Application.GardenAdvisor.Contracts.PlantProfiles;
 
 namespace HomeAssistant.Application.GardenAdvisor.Abstractions;
 

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/Advice/GardenAdviceResponse.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/Advice/GardenAdviceResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 /// <summary>Generated advisory summary for current pot readings and forecast context.</summary>
 public sealed record GardenAdviceResponse(

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/Advice/GardenPotInsightResponse.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/Advice/GardenPotInsightResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 /// <summary>Current insight snapshot for a single pot.</summary>
 public sealed record GardenPotInsightResponse(

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/Advice/GardenWeatherSnapshotResponse.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/Advice/GardenWeatherSnapshotResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 /// <summary>Condensed weather snapshot used for garden decision support.</summary>
 public sealed record GardenWeatherSnapshotResponse(

--- a/HomeAssistant.Application/GardenAdvisor/Contracts/PlantProfiles/PlantProfile.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Contracts/PlantProfiles/PlantProfile.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts;
+﻿namespace HomeAssistant.Application.GardenAdvisor.Contracts.PlantProfiles;
 
 /// <summary>Plant assignment and ideal condition band for a single pot.</summary>
 public sealed record PlantProfile(

--- a/HomeAssistant.Application/GardenAdvisor/Services/GardenAdviceStateStore.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Services/GardenAdviceStateStore.cs
@@ -1,5 +1,5 @@
 ﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 namespace HomeAssistant.Application.GardenAdvisor.Services;
 

--- a/HomeAssistant.Application/GardenAdvisor/Services/GardenAdvisorService.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Services/GardenAdvisorService.cs
@@ -1,10 +1,11 @@
 ﻿using System.Text;
 using System.Text.Json;
 using HomeAssistant.Application.Chat.Abstractions;
-using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.Chat.Contracts.Completions;
 using HomeAssistant.Application.GardenAdvisor.Abstractions;
 using HomeAssistant.Application.GardenAdvisor.Configuration;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
+using HomeAssistant.Application.GardenAdvisor.Contracts.PlantProfiles;
 using HomeAssistant.Application.Messaging.Abstractions;
 using HomeAssistant.Application.Weather.Abstractions;
 using HomeAssistant.Application.Weather.Contracts;

--- a/HomeAssistant.Application/GardenAdvisor/Services/PlantProfileProvider.cs
+++ b/HomeAssistant.Application/GardenAdvisor/Services/PlantProfileProvider.cs
@@ -1,5 +1,5 @@
 ﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.PlantProfiles;
 
 namespace HomeAssistant.Application.GardenAdvisor.Services;
 

--- a/HomeAssistant.Presentation/Chat/Endpoints/PostChatPrompt/PostChatPromptEndpoint.cs
+++ b/HomeAssistant.Presentation/Chat/Endpoints/PostChatPrompt/PostChatPromptEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using HomeAssistant.Application.Chat.Abstractions;
-using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.Chat.Contracts.Completions;
 using HomeAssistant.Presentation.Chat.Services;
+using AppChatCompletionRequest = HomeAssistant.Application.Chat.Contracts.Completions.ChatCompletionRequest;
 
 namespace HomeAssistant.Presentation.Chat.Endpoints.PostChatPrompt;
 
@@ -25,7 +26,7 @@ internal static class PostChatPromptEndpoint
 
                     try
                     {
-                        var completion = new HomeAssistant.Application.Chat.Contracts.ChatCompletionRequest(
+                        var completion = new AppChatCompletionRequest(
                             ChatSystemPromptBuilder.Build(configuration, "helper"),
                             request.Prompt,
                             [],

--- a/HomeAssistant.Presentation/Chat/Endpoints/PostChatSessionMessage/PostChatSessionMessageEndpoint.cs
+++ b/HomeAssistant.Presentation/Chat/Endpoints/PostChatSessionMessage/PostChatSessionMessageEndpoint.cs
@@ -1,8 +1,11 @@
 ﻿using HomeAssistant.Application.Chat.Abstractions;
-using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.Chat.Contracts.Agentic;
+using HomeAssistant.Application.Chat.Contracts.Completions;
 using HomeAssistant.Domain.Assistant.Abstractions;
 using HomeAssistant.Domain.Assistant.Entities;
 using HomeAssistant.Presentation.Chat.Services;
+using AppChatCompletionRequest = HomeAssistant.Application.Chat.Contracts.Completions.ChatCompletionRequest;
+using AppChatHistoryMessage = HomeAssistant.Application.Chat.Contracts.Agentic.ChatHistoryMessage;
 
 namespace HomeAssistant.Presentation.Chat.Endpoints.PostChatSessionMessage;
 
@@ -46,12 +49,12 @@ internal static class PostChatSessionMessageEndpoint
                     var maxHistory = int.TryParse(configuration["Assistant:MaxHistoryMessages"], out var parsedMax) ? parsedMax : 30;
                     var historyMessages = await sessions.GetMessagesAsync(sessionId, maxHistory, ct);
 
-                    var completion = new HomeAssistant.Application.Chat.Contracts.ChatCompletionRequest(
+                    var completion = new AppChatCompletionRequest(
                         ChatSystemPromptBuilder.Build(configuration, session.Capability),
                         request.Prompt.Trim(),
                         historyMessages
                             .Where(m => m.Role is "user" or "assistant")
-                            .Select(m => new HomeAssistant.Application.Chat.Contracts.ChatHistoryMessage(m.Role, m.Content))
+                            .Select(m => new AppChatHistoryMessage(m.Role, m.Content))
                             .ToList(),
                         session.Capability);
 

--- a/HomeAssistant.Presentation/Chat/Services/OllamaChatAssistant.cs
+++ b/HomeAssistant.Presentation/Chat/Services/OllamaChatAssistant.cs
@@ -1,7 +1,13 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 using HomeAssistant.Application.Chat.Abstractions;
-using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.Chat.Contracts.Agentic;
+using HomeAssistant.Application.Chat.Contracts.Completions;
+using AppAgenticChatResult = HomeAssistant.Application.Chat.Contracts.Agentic.AgenticChatResult;
+using AppChatCompletionRequest = HomeAssistant.Application.Chat.Contracts.Completions.ChatCompletionRequest;
+using AppChatFunctionCall = HomeAssistant.Application.Chat.Contracts.Agentic.ChatFunctionCall;
+using AppChatHistoryMessage = HomeAssistant.Application.Chat.Contracts.Agentic.ChatHistoryMessage;
+using AppChatToolDefinition = HomeAssistant.Application.Chat.Contracts.Agentic.ChatToolDefinition;
 
 namespace HomeAssistant.Presentation.Chat.Services;
 
@@ -27,7 +33,7 @@ public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstrac
     }
 
     /// <inheritdoc/>
-    public async Task<string> GetReplyAsync(HomeAssistant.Application.Chat.Contracts.ChatCompletionRequest request, CancellationToken ct = default)
+    public async Task<string> GetReplyAsync(AppChatCompletionRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (string.IsNullOrWhiteSpace(request.Prompt))
@@ -48,12 +54,12 @@ public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstrac
     }
 
     /// <inheritdoc/>
-    public async Task<HomeAssistant.Application.Chat.Contracts.AgenticChatResult> GetAgenticReplyAsync(
+    public async Task<AppAgenticChatResult> GetAgenticReplyAsync(
         string systemPrompt,
-        IReadOnlyList<HomeAssistant.Application.Chat.Contracts.ChatHistoryMessage> history,
+        IReadOnlyList<AppChatHistoryMessage> history,
         string userMessage,
-        IReadOnlyList<HomeAssistant.Application.Chat.Contracts.ChatToolDefinition> tools,
-        Func<HomeAssistant.Application.Chat.Contracts.ChatFunctionCall, CancellationToken, Task<string>> toolExecutor,
+        IReadOnlyList<AppChatToolDefinition> tools,
+        Func<AppChatFunctionCall, CancellationToken, Task<string>> toolExecutor,
         int maxIterations = 5,
         CancellationToken ct = default)
     {
@@ -65,7 +71,7 @@ public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstrac
 
         var model = _configuration["Ollama:Model"] ?? "llama3.2:3b";
         var ollamaTools = tools.Select(MapToOllamaTool).ToList();
-        var executedCalls = new List<HomeAssistant.Application.Chat.Contracts.ChatFunctionCall>();
+        var executedCalls = new List<AppChatFunctionCall>();
 
         // Build working message list: system + history + new user message
         var messages = new List<OllamaMessage> { new("system", systemPrompt) };
@@ -114,7 +120,7 @@ public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstrac
                         ? JsonSerializer.Serialize(tc.Function.Arguments, JsonOptions)
                         : "{}";
 
-                    var call = new HomeAssistant.Application.Chat.Contracts.ChatFunctionCall(funcName, argsJson);
+                    var call = new AppChatFunctionCall(funcName, argsJson);
                     executedCalls.Add(call);
 
                     _logger.LogInformation("Executing tool call: {FunctionName}({Args}).", funcName, argsJson);
@@ -129,11 +135,11 @@ public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstrac
 
             // ── Text response — we're done ───────────────────────────────
             var text = result.Message.Content?.Trim() ?? string.Empty;
-            return new HomeAssistant.Application.Chat.Contracts.AgenticChatResult(text, executedCalls.AsReadOnly());
+            return new AppAgenticChatResult(text, executedCalls.AsReadOnly());
         }
 
         _logger.LogWarning("Agentic loop hit max iterations ({Max}); returning partial result.", maxIterations);
-        return new HomeAssistant.Application.Chat.Contracts.AgenticChatResult(
+        return new AppAgenticChatResult(
             "I've processed your request but ran out of reasoning steps. Please try again.",
             executedCalls.AsReadOnly());
     }
@@ -171,7 +177,7 @@ public sealed class OllamaChatAssistant : HomeAssistant.Application.Chat.Abstrac
 
     // ── Mapping helpers ───────────────────────────────────────────────────
 
-    private static OllamaTool MapToOllamaTool(HomeAssistant.Application.Chat.Contracts.ChatToolDefinition def)
+    private static OllamaTool MapToOllamaTool(AppChatToolDefinition def)
     {
         var props = def.Properties.ToDictionary(
             kv => kv.Key,

--- a/HomeAssistant.Presentation/GardenAdvisor/Abstractions/IGardenPlannerFunctionService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Abstractions/IGardenPlannerFunctionService.cs
@@ -1,5 +1,7 @@
 ﻿using HomeAssistant.Presentation.GardenAdvisor.Contracts;
 using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PlannerFunctions.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
+using AppGardenAdviceResponse = HomeAssistant.Application.GardenAdvisor.Contracts.Advice.GardenAdviceResponse;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Abstractions;
 
@@ -37,10 +39,10 @@ public interface IGardenPlannerFunctionService
     Task<IReadOnlyList<HarvestReadinessResponse>> GetHarvestReadinessAsync(HarvestReadinessFunctionRequest request, CancellationToken ct = default);
 
     /// <summary>Returns the latest in-memory garden advice, if available.</summary>
-    HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse? GetLatestAdvice();
+    AppGardenAdviceResponse? GetLatestAdvice();
 
     /// <summary>Generates fresh garden advice and optionally publishes MQTT updates.</summary>
-    Task<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default);
+    Task<AppGardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default);
 
     /// <summary>Clears the in-memory planner chat history.</summary>
     string ClearPlannerHistory();

--- a/HomeAssistant.Presentation/GardenAdvisor/Endpoints/GetLatestGardenAdvice/GetLatestGardenAdviceEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Endpoints/GetLatestGardenAdvice/GetLatestGardenAdviceEndpoint.cs
@@ -1,5 +1,5 @@
 ﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.GetLatestGardenAdvice;
 

--- a/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PlannerFunctions/GardenPlannerFunctionEndpoints.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PlannerFunctions/GardenPlannerFunctionEndpoints.cs
@@ -1,6 +1,8 @@
 ﻿using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 using HomeAssistant.Presentation.GardenAdvisor.Contracts;
 using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PlannerFunctions.Contracts;
+using AppGardenAdviceResponse = HomeAssistant.Application.GardenAdvisor.Contracts.Advice.GardenAdviceResponse;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PlannerFunctions;
@@ -73,14 +75,14 @@ public static class GardenPlannerFunctionEndpoints
         group.MapGet("/advice/latest", GetLatestAdvice)
             .WithName("PlannerFunctionGetLatestAdvice")
             .WithOpenApi()
-            .Produces<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>(StatusCodes.Status200OK)
+            .Produces<AppGardenAdviceResponse>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
 
         group.MapPost("/advice/generate", GenerateAdvice)
             .WithName("PlannerFunctionGenerateAdvice")
             .WithOpenApi()
             .Accepts<GeneratePlannerAdviceFunctionRequest>("application/json")
-            .Produces<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>(StatusCodes.Status200OK);
+            .Produces<AppGardenAdviceResponse>(StatusCodes.Status200OK);
 
         group.MapPost("/history/clear", ClearHistory)
             .WithName("PlannerFunctionClearHistory")
@@ -192,7 +194,7 @@ public static class GardenPlannerFunctionEndpoints
         return TypedResults.Ok(await service.GetHarvestReadinessAsync(new HarvestReadinessFunctionRequest(filterByStatus), ct));
     }
 
-    private static Results<Ok<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>, NotFound> GetLatestAdvice(IGardenPlannerFunctionService service)
+    private static Results<Ok<AppGardenAdviceResponse>, NotFound> GetLatestAdvice(IGardenPlannerFunctionService service)
     {
         ArgumentNullException.ThrowIfNull(service);
 
@@ -200,7 +202,7 @@ public static class GardenPlannerFunctionEndpoints
         return latest is null ? TypedResults.NotFound() : TypedResults.Ok(latest);
     }
 
-    private static async Task<Ok<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>> GenerateAdvice(
+    private static async Task<Ok<AppGardenAdviceResponse>> GenerateAdvice(
         GeneratePlannerAdviceFunctionRequest? request,
         IGardenPlannerFunctionService service,
         CancellationToken ct)

--- a/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PostGenerateGardenAdvice/PostGenerateGardenAdviceEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Endpoints/PostGenerateGardenAdvice/PostGenerateGardenAdviceEndpoint.cs
@@ -1,5 +1,5 @@
 ﻿using HomeAssistant.Application.GardenAdvisor.Abstractions;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGenerateGardenAdvice.Contracts;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGenerateGardenAdvice;
@@ -35,7 +35,7 @@ internal static class PostGenerateGardenAdviceEndpoint
             .WithName("PostGenerateGardenAdvice")
             .WithSummary("Generates a new advice summary from latest sensor and weather data")
             .WithDescription("Triggers Ollama to evaluate the latest pot state with weather context and optional MQTT publication.")
-            .Produces<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse>()
+            .Produces<GardenAdviceResponse>()
             .ProducesProblem(StatusCodes.Status502BadGateway);
     }
 }

--- a/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerFunctionService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerFunctionService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text;
 using HomeAssistant.Application.Dispatching;
 using HomeAssistant.Application.GardenAdvisor.Abstractions;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 using HomeAssistant.Application.PotConfigurations.Abstractions;
 using HomeAssistant.Application.PotConfigurations.Commands;
 using HomeAssistant.Application.PotConfigurations.DTOs;
@@ -12,6 +12,7 @@ using HomeAssistant.Domain.SensorReadings.Abstractions;
 using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
 using HomeAssistant.Presentation.GardenAdvisor.Contracts;
 using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PlannerFunctions.Contracts;
+using AppGardenAdviceResponse = HomeAssistant.Application.GardenAdvisor.Contracts.Advice.GardenAdviceResponse;
 using SavePotConfigurationCommandRequest = HomeAssistant.Application.PotConfigurations.Commands.SavePotConfigurationRequest;
 using SeedAssignmentCommandRequest = HomeAssistant.Application.PotConfigurations.Commands.SeedAssignmentRequest;
 
@@ -226,10 +227,10 @@ public sealed class GardenPlannerFunctionService : IGardenPlannerFunctionService
     }
 
     /// <inheritdoc/>
-    public HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse? GetLatestAdvice() => _adviceStateStore.GetLatest();
+    public AppGardenAdviceResponse? GetLatestAdvice() => _adviceStateStore.GetLatest();
 
     /// <inheritdoc/>
-    public Task<HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default)
+    public Task<AppGardenAdviceResponse> GenerateAdviceAsync(GeneratePlannerAdviceFunctionRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
         return _gardenAdvisorService.GenerateAdviceAsync(request.PublishToMqtt, ct);

--- a/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerService.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/Services/GardenPlannerService.cs
@@ -2,10 +2,11 @@
 using System.Text;
 using System.Text.Json;
 using HomeAssistant.Application.Chat.Abstractions;
-using HomeAssistant.Application.Chat.Contracts;
+using HomeAssistant.Application.Chat.Contracts.Agentic;
+using HomeAssistant.Application.Chat.Contracts.Completions;
 using HomeAssistant.Application.GardenAdvisor.Abstractions;
 using HomeAssistant.Application.GardenAdvisor.Configuration;
-using HomeAssistant.Application.GardenAdvisor.Contracts;
+using HomeAssistant.Application.GardenAdvisor.Contracts.Advice;
 using HomeAssistant.Application.Messaging.Abstractions;
 using HomeAssistant.Application.PotConfigurations.Abstractions;
 using HomeAssistant.Domain.PotConfigurations.Abstractions;
@@ -13,6 +14,7 @@ using HomeAssistant.Presentation.GardenAdvisor.Abstractions;
 using HomeAssistant.Presentation.GardenAdvisor.Contracts;
 using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PlannerFunctions.Contracts;
 using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGardenPlannerChat.Contracts;
+using AppGardenAdviceResponse = HomeAssistant.Application.GardenAdvisor.Contracts.Advice.GardenAdviceResponse;
 using Microsoft.Extensions.Options;
 
 namespace HomeAssistant.Presentation.GardenAdvisor.Services;
@@ -292,12 +294,12 @@ public sealed class GardenPlannerService : IGardenPlannerService
             ? "No harvest-readiness items were found."
             : string.Join(" ", items.Select(i => $"{i.PlantName}/{i.SeedName} in pot {i.PotId}: score {i.ReadinessScore}, category {i.ReadinessCategory}."));
 
-    private static string FormatLatestAdvice(HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse? advice)
+    private static string FormatLatestAdvice(AppGardenAdviceResponse? advice)
         => advice is null
             ? "No garden advice has been generated yet."
             : $"Latest advice ({advice.GeneratedAtUtc:O}): {advice.RecommendationSummary}";
 
-    private static string FormatAdvice(HomeAssistant.Application.GardenAdvisor.Contracts.GardenAdviceResponse advice)
+    private static string FormatAdvice(AppGardenAdviceResponse advice)
         => $"Generated advice ({advice.GeneratedAtUtc:O}): {advice.RecommendationSummary}";
 
     private static string FormatActionDescription(ChatFunctionCall call)


### PR DESCRIPTION
Closes #24
## Summary
- move Application chat contracts into Contracts/Completions and Contracts/Agentic
- move Application garden advisor contracts into Contracts/Advice and Contracts/PlantProfiles
- update Application and Presentation references to the new namespaces with no behavior change
## Validation
- dotnet build HomeAssistant.sln