### PR TITLE
refactor(routes): introduce domain route builders for GardenAdvisor slices

### DIFF
--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenAdviceRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenAdviceRouteBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
+
+/// <summary>Maps garden-advice route boundaries for GardenAdvisor.</summary>
+public static class GardenAdviceRouteBuilder
+{
+    /// <summary>
+    /// Maps garden-advice routes.
+    /// Route paths are preserved by leaving this slice as a no-op until endpoint re-homing lands.
+    /// </summary>
+    public static IEndpointRouteBuilder MapGardenAdviceRoutes(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        return endpoints;
+    }
+}
+

--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenAdvisorRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenAdvisorRouteBuilder.cs
@@ -1,9 +1,6 @@
-﻿using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGardenPlannerChat;
-using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGardenPlannerChat.Contracts;
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
 
-namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
-
-/// <summary>Maps all garden advisor endpoints.</summary>
+/// <summary>Maps all garden advisor routes through domain-sliced route builders.</summary>
 public static class GardenAdvisorRouteBuilder
 {
     /// <summary>Maps garden advisor routes under <c>/api/garden</c>.</summary>
@@ -11,17 +8,11 @@ public static class GardenAdvisorRouteBuilder
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
-        var plannerGroup = endpoints.MapGroup("/api/garden/planner")
-            .WithTags("GardenPlanner");
-
-        plannerGroup
-            .MapPost("/chat", PostGardenPlannerChatEndpoint.Handle)
-            .WithName("GardenPlannerChat")
-            .WithOpenApi()
-            .Accepts<GardenPlannerChatRequest>("application/json")
-            .Produces<GardenPlannerChatResponse>(StatusCodes.Status200OK)
-            .Produces<string>(StatusCodes.Status400BadRequest);
-
+        endpoints.MapGardenPlanningRoutes();
+        endpoints.MapPotManagementRoutes();
+        endpoints.MapRoomInsightsRoutes();
+        endpoints.MapGardenInsightsRoutes();
+        endpoints.MapGardenAdviceRoutes();
 
         return endpoints;
     }

--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenInsightsRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenInsightsRouteBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
+
+/// <summary>Maps garden-insight route boundaries for GardenAdvisor.</summary>
+public static class GardenInsightsRouteBuilder
+{
+    /// <summary>
+    /// Maps garden-insight routes.
+    /// Route paths are preserved by leaving this slice as a no-op until endpoint re-homing lands.
+    /// </summary>
+    public static IEndpointRouteBuilder MapGardenInsightsRoutes(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        return endpoints;
+    }
+}
+

--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenPlanningRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/GardenPlanningRouteBuilder.cs
@@ -1,0 +1,28 @@
+﻿using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGardenPlannerChat;
+using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostGardenPlannerChat.Contracts;
+
+namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
+
+/// <summary>Maps garden planning routes.</summary>
+public static class GardenPlanningRouteBuilder
+{
+    /// <summary>Maps planning-related routes under <c>/api/garden/planner</c>.</summary>
+    public static IEndpointRouteBuilder MapGardenPlanningRoutes(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var plannerGroup = endpoints.MapGroup("/api/garden/planner")
+            .WithTags("GardenPlanner");
+
+        plannerGroup
+            .MapPost("/chat", PostGardenPlannerChatEndpoint.Handle)
+            .WithName("GardenPlannerChat")
+            .WithOpenApi()
+            .Accepts<GardenPlannerChatRequest>("application/json")
+            .Produces<GardenPlannerChatResponse>(StatusCodes.Status200OK)
+            .Produces<string>(StatusCodes.Status400BadRequest);
+
+        return endpoints;
+    }
+}
+

--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/PotManagementRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/PotManagementRouteBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
+
+/// <summary>Maps pot-management route boundaries for GardenAdvisor.</summary>
+public static class PotManagementRouteBuilder
+{
+    /// <summary>
+    /// Maps pot-management routes.
+    /// Route paths are preserved by leaving this slice as a no-op until endpoint re-homing lands.
+    /// </summary>
+    public static IEndpointRouteBuilder MapPotManagementRoutes(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        return endpoints;
+    }
+}
+

--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/RoomInsightsRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/RoomInsightsRouteBuilder.cs
@@ -1,0 +1,16 @@
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
+
+/// <summary>Maps room-insight route boundaries for GardenAdvisor.</summary>
+public static class RoomInsightsRouteBuilder
+{
+    /// <summary>
+    /// Maps room-insight routes.
+    /// Route paths are preserved by leaving this slice as a no-op until endpoint re-homing lands.
+    /// </summary>
+    public static IEndpointRouteBuilder MapRoomInsightsRoutes(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        return endpoints;
+    }
+}
+


### PR DESCRIPTION
Closes #33
## Summary
- split GardenAdvisor root route mapping into domain-oriented route builders
- introduce GardenPlanningRouteBuilder, PotManagementRouteBuilder, RoomInsightsRouteBuilder, GardenInsightsRouteBuilder, and GardenAdviceRouteBuilder
- preserve existing route behavior by moving current planner chat mapping into GardenPlanningRouteBuilder and leaving other slices as boundary no-ops for follow-up sub-issues
## Validation
- dotnet build HomeAssistant.sln