### PR TITLE
refactor(presentation): re-home pot-management endpoints and contracts

### DIFF
--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Contracts/PotConfigurationResponse.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Contracts/PotConfigurationResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Presentation.GardenAdvisor.Contracts;
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Contracts;
 
 /// <summary>Response model for a pot's configuration (room + seeds).</summary>
 /// <param name="PotId">The pot ID.</param>

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Contracts/SeedAssignmentResponse.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Contracts/SeedAssignmentResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Presentation.GardenAdvisor.Contracts;
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Contracts;
 
 /// <summary>Represents a single seed assignment in a pot configuration response.</summary>
 /// <param name="Id">Unique identifier for this seed assignment.</param>

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/GetPotConfiguration/GetPotConfigurationEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/GetPotConfiguration/GetPotConfigurationEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿using HomeAssistant.Domain.PotConfigurations.Abstractions;
-using HomeAssistant.Presentation.GardenAdvisor.Contracts;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Contracts;
 using Microsoft.AspNetCore.Http.HttpResults;
 
-namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.GetPotConfiguration;
+namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.GetPotConfiguration;
 
 /// <summary>Endpoint to retrieve a pot's configuration (room + seeds).</summary>
 public sealed class GetPotConfigurationEndpoint

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostSavePotConfiguration/Contracts/SavePotConfigurationRequest.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostSavePotConfiguration/Contracts/SavePotConfigurationRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostSavePotConfiguration.Contracts;
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostSavePotConfiguration.Contracts;
 
 /// <summary>Request model for saving a pot's room assignment and seed configuration.</summary>
 public sealed record SavePotConfigurationRequest(

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostSavePotConfiguration/Contracts/SeedAssignmentRequest.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostSavePotConfiguration/Contracts/SeedAssignmentRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostSavePotConfiguration.Contracts;
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostSavePotConfiguration.Contracts;
 
 /// <summary>Represents a single seed assignment submitted when saving a pot configuration.</summary>
 public sealed record SeedAssignmentRequest(

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostSavePotConfiguration/PostSavePotConfigurationEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostSavePotConfiguration/PostSavePotConfigurationEndpoint.cs
@@ -1,13 +1,13 @@
 ﻿using HomeAssistant.Application.Dispatching;
 using HomeAssistant.Domain.PotConfigurations.Abstractions;
-using HomeAssistant.Presentation.GardenAdvisor.Contracts;
-using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostSavePotConfiguration.Contracts;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Contracts;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostSavePotConfiguration.Contracts;
 using Microsoft.AspNetCore.Http.HttpResults;
 using SavePotConfigurationCommand = HomeAssistant.Application.PotConfigurations.Commands.SavePotConfigurationCommand;
 using SavePotConfigurationCommandRequest = HomeAssistant.Application.PotConfigurations.Commands.SavePotConfigurationRequest;
 using SeedAssignmentCommandRequest = HomeAssistant.Application.PotConfigurations.Commands.SeedAssignmentRequest;
 
-namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostSavePotConfiguration;
+namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostSavePotConfiguration;
 
 /// <summary>Endpoint to save/update a pot's configuration (room + seeds).</summary>
 public sealed class PostSavePotConfigurationEndpoint

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostUpdateSeedStatus/Contracts/UpdateSeedStatusRequest.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostUpdateSeedStatus/Contracts/UpdateSeedStatusRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostUpdateSeedStatus.Contracts;
+﻿namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostUpdateSeedStatus.Contracts;
 
 /// <summary>Request model for updating a seed's lifecycle status.</summary>
 /// <param name="NewStatus">The new lifecycle status (<c>growing</c>, <c>mature</c>, <c>harvested</c>, or <c>removed</c>).</param>

--- a/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostUpdateSeedStatus/PostUpdateSeedStatusEndpoint.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/PotManagement/Endpoints/PostUpdateSeedStatus/PostUpdateSeedStatusEndpoint.cs
@@ -1,9 +1,9 @@
 ﻿using HomeAssistant.Application.PotConfigurations.Commands;
 using HomeAssistant.Application.Dispatching;
-using HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostUpdateSeedStatus.Contracts;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostUpdateSeedStatus.Contracts;
 using Microsoft.AspNetCore.Http.HttpResults;
 
-namespace HomeAssistant.Presentation.GardenAdvisor.Endpoints.PostUpdateSeedStatus;
+namespace HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostUpdateSeedStatus;
 
 /// <summary>Endpoint: POST /api/garden/pots/{potId}/seeds/{seedId}/status – Update a seed's lifecycle status.</summary>
 public sealed class PostUpdateSeedStatusEndpoint

--- a/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/PotManagementRouteBuilder.cs
+++ b/HomeAssistant.Presentation/GardenAdvisor/RouteBuilders/PotManagementRouteBuilder.cs
@@ -1,15 +1,46 @@
-﻿namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
+﻿using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Contracts;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.GetPotConfiguration;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostSavePotConfiguration;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostSavePotConfiguration.Contracts;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostUpdateSeedStatus;
+using HomeAssistant.Presentation.GardenAdvisor.PotManagement.Endpoints.PostUpdateSeedStatus.Contracts;
+
+namespace HomeAssistant.Presentation.GardenAdvisor.RouteBuilders;
 
 /// <summary>Maps pot-management route boundaries for GardenAdvisor.</summary>
 public static class PotManagementRouteBuilder
 {
-    /// <summary>
-    /// Maps pot-management routes.
-    /// Route paths are preserved by leaving this slice as a no-op until endpoint re-homing lands.
-    /// </summary>
+    /// <summary>Maps pot-management routes while preserving existing API paths.</summary>
     public static IEndpointRouteBuilder MapPotManagementRoutes(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
+
+        var potsGroup = endpoints.MapGroup("/api/garden/pots")
+            .WithTags("GardenPlanner");
+
+        potsGroup
+            .MapGet("/{potId:guid}/configuration", GetPotConfigurationEndpoint.Handle)
+            .WithName("GetPotConfiguration")
+            .WithOpenApi()
+            .Produces<PotConfigurationResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
+
+        potsGroup
+            .MapPost("/{potId:guid}/configuration", PostSavePotConfigurationEndpoint.Handle)
+            .WithName("SavePotConfiguration")
+            .WithOpenApi()
+            .Accepts<SavePotConfigurationRequest>("application/json")
+            .Produces<PotConfigurationResponse>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest);
+
+        potsGroup
+            .MapPost("/{potId:guid}/seeds/{seedId:guid}/status", PostUpdateSeedStatusEndpoint.Handle)
+            .WithName("UpdateSeedStatus")
+            .WithOpenApi()
+            .Accepts<UpdateSeedStatusRequest>("application/json")
+            .Produces(StatusCodes.Status200OK)
+            .Produces<string>(StatusCodes.Status400BadRequest);
+
         return endpoints;
     }
 }


### PR DESCRIPTION
## Summary
- move pot-management endpoints into PotManagement feature scope
- move associated pot-management contracts with endpoint-local and feature-level placement
- wire PotManagement route builder to map existing pot-management routes without behavior changes

Closes #35