### PR TITLE
feat(application,presentation): scaffold home assistant sync infrastructure

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />

--- a/GardenAI.Application/Area/Commands/UpsertAreaCommand.cs
+++ b/GardenAI.Application/Area/Commands/UpsertAreaCommand.cs
@@ -1,0 +1,11 @@
+﻿using GardenAI.Domain.Common.Markers;
+
+namespace GardenAI.Application.Area.Commands;
+
+/// <summary>Creates or updates an area in the local DB from a HA event or REST fetch.</summary>
+public sealed record UpsertAreaCommand(
+    string AreaId,
+    string Name,
+    string? Icon,
+    string? AliasesJson) : ICommand;
+

--- a/GardenAI.Application/Area/Commands/UpsertAreaCommandHandler.cs
+++ b/GardenAI.Application/Area/Commands/UpsertAreaCommandHandler.cs
@@ -1,0 +1,35 @@
+﻿using GardenAI.Domain.Area.Abstractions;
+using GardenAI.Domain.Area.Entities;
+using GardenAI.Domain.Common.Handlers;
+
+namespace GardenAI.Application.Area.Commands;
+
+/// <summary>Handles <see cref="UpsertAreaCommand"/>.</summary>
+public sealed class UpsertAreaCommandHandler : ICommandHandler<UpsertAreaCommand>
+{
+    private readonly IAreaRepository _repo;
+
+    public UpsertAreaCommandHandler(IAreaRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public async Task HandleAsync(UpsertAreaCommand command, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var now = DateTime.UtcNow;
+        var entity = new AreaEntity
+        {
+            Id = command.AreaId,
+            Name = command.Name,
+            Icon = command.Icon,
+            Aliases = command.AliasesJson,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await _repo.UpsertAsync(entity, ct);
+    }
+}
+

--- a/GardenAI.Application/Area/Contracts/HaAreaDto.cs
+++ b/GardenAI.Application/Area/Contracts/HaAreaDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace GardenAI.Application.Area.Contracts;
+
+/// <summary>DTO for an area received from the Home Assistant REST API.</summary>
+public sealed record HaAreaDto
+{
+    [JsonPropertyName("area_id")]
+    public string AreaId { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("icon")]
+    public string? Icon { get; init; }
+
+    [JsonPropertyName("aliases")]
+    public string[]? Aliases { get; init; }
+}
+
+

--- a/GardenAI.Application/Area/Dtos/AreaDto.cs
+++ b/GardenAI.Application/Area/Dtos/AreaDto.cs
@@ -1,0 +1,5 @@
+﻿namespace GardenAI.Application.Area.Dtos;
+
+/// <summary>Read model for a synced Home Assistant area.</summary>
+public sealed record AreaDto(string Id, string Name, string? Icon);
+

--- a/GardenAI.Application/Common/Sync/Abstractions/IHomeAssistantRestClient.cs
+++ b/GardenAI.Application/Common/Sync/Abstractions/IHomeAssistantRestClient.cs
@@ -1,0 +1,23 @@
+using GardenAI.Application.Area.Contracts;
+using GardenAI.Application.Device.Contracts;
+using GardenAI.Application.Entity.Contracts;
+
+namespace GardenAI.Application.Common.Sync.Abstractions;
+
+/// <summary>
+/// REST client for the Home Assistant API.
+/// Used to fetch the initial full registry snapshot at startup.
+/// </summary>
+public interface IHomeAssistantRestClient
+{
+    /// <summary>Fetches all areas from GET /api/config/area_registry/list.</summary>
+    Task<IReadOnlyList<HaAreaDto>> GetAreasAsync(CancellationToken ct = default);
+
+    /// <summary>Fetches all devices from GET /api/config/device_registry/list.</summary>
+    Task<IReadOnlyList<HaDeviceDto>> GetDevicesAsync(CancellationToken ct = default);
+
+    /// <summary>Fetches all entities from GET /api/config/entity_registry/list.</summary>
+    Task<IReadOnlyList<HaEntityDto>> GetEntitiesAsync(CancellationToken ct = default);
+}
+
+

--- a/GardenAI.Application/Common/Sync/Abstractions/IHomeAssistantWebSocketClient.cs
+++ b/GardenAI.Application/Common/Sync/Abstractions/IHomeAssistantWebSocketClient.cs
@@ -1,0 +1,30 @@
+using GardenAI.Application.Common.Sync.Contracts;
+
+namespace GardenAI.Application.Common.Sync.Abstractions;
+
+/// <summary>
+/// WebSocket client for the Home Assistant real-time API.
+/// Handles authentication, message ID sequencing, event subscriptions, and keepalive pings.
+/// </summary>
+public interface IHomeAssistantWebSocketClient
+{
+    /// <summary>Connects to the HA WebSocket endpoint and completes the auth handshake.</summary>
+    Task ConnectAsync(CancellationToken ct = default);
+
+    /// <summary>Gracefully closes the WebSocket connection.</summary>
+    Task DisconnectAsync(CancellationToken ct = default);
+
+    /// <summary>Sends a typed message to HA and returns the next outbound message ID used.</summary>
+    Task<int> SendAsync<T>(T message, CancellationToken ct = default);
+
+    /// <summary>Subscribes to a HA event type and begins buffering events into the registry event channel.</summary>
+    Task SubscribeToEventAsync(string eventType, CancellationToken ct = default);
+
+    /// <summary>Unsubscribes from a previously subscribed event type.</summary>
+    Task UnsubscribeFromEventAsync(string eventType, CancellationToken ct = default);
+
+    /// <summary>Reads the next registry event from the incoming event channel. Returns null when closed.</summary>
+    Task<HaRegistryEvent?> ReadNextEventAsync(CancellationToken ct = default);
+}
+
+

--- a/GardenAI.Application/Common/Sync/Abstractions/IRegistryEventHandler.cs
+++ b/GardenAI.Application/Common/Sync/Abstractions/IRegistryEventHandler.cs
@@ -1,0 +1,12 @@
+using GardenAI.Application.Common.Sync.Contracts;
+
+namespace GardenAI.Application.Common.Sync.Abstractions;
+
+/// <summary>Handles a specific type of Home Assistant registry change event.</summary>
+public interface IRegistryEventHandler
+{
+    /// <summary>Processes the event and applies the appropriate DB mutations.</summary>
+    Task HandleAsync(HaRegistryEvent evt, CancellationToken ct = default);
+}
+
+

--- a/GardenAI.Application/Common/Sync/Abstractions/ISyncOrchestrator.cs
+++ b/GardenAI.Application/Common/Sync/Abstractions/ISyncOrchestrator.cs
@@ -1,0 +1,22 @@
+namespace GardenAI.Application.Common.Sync.Abstractions;
+
+/// <summary>
+/// Orchestrates the initial HA registry sync using the Subscribe-Before-Fetch pattern
+/// to eliminate the race condition between REST fetch completion and WebSocket event activation.
+/// </summary>
+public interface ISyncOrchestrator
+{
+    /// <summary>Gets the current sync state.</summary>
+    SyncState State { get; }
+
+    /// <summary>
+    /// Runs the full initial sync:
+    /// 1. Subscribe to registry events (buffer incoming events).
+    /// 2. Fetch current state via REST and upsert into DB (Areas ? Devices ? Entities).
+    /// 3. Drain buffered events received during the fetch.
+    /// 4. Transition to live event processing.
+    /// </summary>
+    Task RunInitialSyncAsync(CancellationToken ct = default);
+}
+
+

--- a/GardenAI.Application/Common/Sync/Abstractions/SyncState.cs
+++ b/GardenAI.Application/Common/Sync/Abstractions/SyncState.cs
@@ -1,0 +1,19 @@
+namespace GardenAI.Application.Common.Sync.Abstractions;
+
+/// <summary>Represents the current state of the HA sync pipeline.</summary>
+public enum SyncState
+{
+    /// <summary>Sync has not started yet.</summary>
+    Unsynced,
+
+    /// <summary>Initial sync is in progress.</summary>
+    Syncing,
+
+    /// <summary>Initial sync completed successfully and the event loop is active.</summary>
+    Synced,
+
+    /// <summary>Sync failed due to an unrecoverable error.</summary>
+    Error
+}
+
+

--- a/GardenAI.Application/Common/Sync/Configuration/HomeAssistantOptions.cs
+++ b/GardenAI.Application/Common/Sync/Configuration/HomeAssistantOptions.cs
@@ -1,0 +1,22 @@
+namespace GardenAI.Application.Common.Sync.Configuration;
+
+/// <summary>Configuration options for the Home Assistant connection.</summary>
+public sealed class HomeAssistantOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "HomeAssistant";
+
+    /// <summary>Base URL of the Home Assistant instance (e.g. http://homeassistant.local:8123).</summary>
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>Long-lived access token for authenticating with the HA WebSocket and REST API.</summary>
+    public string AccessToken { get; set; } = string.Empty;
+
+    /// <summary>Interval in seconds between WebSocket keepalive ping messages.</summary>
+    public int PingIntervalSeconds { get; set; } = 30;
+
+    /// <summary>Maximum number of reconnect attempts before giving up.</summary>
+    public int ReconnectMaxRetries { get; set; } = 10;
+}
+
+

--- a/GardenAI.Application/Common/Sync/Contracts/HaRegistryEvent.cs
+++ b/GardenAI.Application/Common/Sync/Contracts/HaRegistryEvent.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace GardenAI.Application.Common.Sync.Contracts;
+
+/// <summary>Represents a registry change event received from the Home Assistant WebSocket API.</summary>
+public sealed record HaRegistryEvent
+{
+    /// <summary>The event type (e.g. "area_registry_updated").</summary>
+    public string EventType { get; init; } = string.Empty;
+
+    /// <summary>Raw JSON data payload from HA. Deserialised by each event handler.</summary>
+    public JsonElement Data { get; init; }
+}
+
+/// <summary>Payload for area_registry_updated events.</summary>
+public sealed record HaAreaRegistryEventData
+{
+    [JsonPropertyName("action")]
+    public string Action { get; init; } = string.Empty;
+
+    [JsonPropertyName("area_id")]
+    public string AreaId { get; init; } = string.Empty;
+}
+
+/// <summary>Payload for device_registry_updated events.</summary>
+public sealed record HaDeviceRegistryEventData
+{
+    [JsonPropertyName("action")]
+    public string Action { get; init; } = string.Empty;
+
+    [JsonPropertyName("device_id")]
+    public string DeviceId { get; init; } = string.Empty;
+
+    [JsonPropertyName("area_id")]
+    public string? AreaId { get; init; }
+}
+
+/// <summary>Payload for entity_registry_updated events.</summary>
+public sealed record HaEntityRegistryEventData
+{
+    [JsonPropertyName("action")]
+    public string Action { get; init; } = string.Empty;
+
+    [JsonPropertyName("entity_id")]
+    public string EntityId { get; init; } = string.Empty;
+
+    [JsonPropertyName("device_id")]
+    public string? DeviceId { get; init; }
+
+    [JsonPropertyName("area_id")]
+    public string? AreaId { get; init; }
+}
+
+

--- a/GardenAI.Application/Device/Commands/UpsertDeviceCommand.cs
+++ b/GardenAI.Application/Device/Commands/UpsertDeviceCommand.cs
@@ -1,0 +1,13 @@
+﻿using GardenAI.Domain.Common.Markers;
+
+namespace GardenAI.Application.Device.Commands;
+
+/// <summary>Creates or updates a device in the local DB from a HA event or REST fetch.</summary>
+public sealed record UpsertDeviceCommand(
+    string DeviceId,
+    string? AreaId,
+    string Name,
+    string? NameByUser,
+    string? Manufacturer,
+    string? Model) : ICommand;
+

--- a/GardenAI.Application/Device/Commands/UpsertDeviceCommandHandler.cs
+++ b/GardenAI.Application/Device/Commands/UpsertDeviceCommandHandler.cs
@@ -1,0 +1,37 @@
+﻿using GardenAI.Domain.Common.Handlers;
+using GardenAI.Domain.Device.Abstractions;
+using GardenAI.Domain.Device.Entities;
+
+namespace GardenAI.Application.Device.Commands;
+
+/// <summary>Handles <see cref="UpsertDeviceCommand"/>.</summary>
+public sealed class UpsertDeviceCommandHandler : ICommandHandler<UpsertDeviceCommand>
+{
+    private readonly IDeviceRepository _repo;
+
+    public UpsertDeviceCommandHandler(IDeviceRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public async Task HandleAsync(UpsertDeviceCommand command, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var now = DateTime.UtcNow;
+        var entity = new DeviceEntity
+        {
+            Id = command.DeviceId,
+            AreaId = command.AreaId,
+            Name = command.Name,
+            NameByUser = command.NameByUser,
+            Manufacturer = command.Manufacturer,
+            Model = command.Model,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        await _repo.UpsertAsync(entity, ct);
+    }
+}
+

--- a/GardenAI.Application/Device/Contracts/HaDeviceDto.cs
+++ b/GardenAI.Application/Device/Contracts/HaDeviceDto.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace GardenAI.Application.Device.Contracts;
+
+/// <summary>DTO for a device received from the Home Assistant REST API.</summary>
+public sealed record HaDeviceDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("area_id")]
+    public string? AreaId { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("name_by_user")]
+    public string? NameByUser { get; init; }
+
+    [JsonPropertyName("manufacturer")]
+    public string? Manufacturer { get; init; }
+
+    [JsonPropertyName("model")]
+    public string? Model { get; init; }
+}
+
+

--- a/GardenAI.Application/Device/Dtos/DeviceDto.cs
+++ b/GardenAI.Application/Device/Dtos/DeviceDto.cs
@@ -1,0 +1,5 @@
+﻿namespace GardenAI.Application.Device.Dtos;
+
+/// <summary>Read model for a synced Home Assistant device.</summary>
+public sealed record DeviceDto(string Id, string? AreaId, string Name, string? Manufacturer, string? Model);
+

--- a/GardenAI.Application/Entity/Contracts/HaEntityDto.cs
+++ b/GardenAI.Application/Entity/Contracts/HaEntityDto.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace GardenAI.Application.Entity.Contracts;
+
+/// <summary>DTO for an entity received from the Home Assistant REST API.</summary>
+public sealed record HaEntityDto
+{
+    [JsonPropertyName("entity_id")]
+    public string EntityId { get; init; } = string.Empty;
+
+    [JsonPropertyName("device_id")]
+    public string? DeviceId { get; init; }
+
+    [JsonPropertyName("area_id")]
+    public string? AreaId { get; init; }
+
+    [JsonPropertyName("platform")]
+    public string Platform { get; init; } = string.Empty;
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("original_name")]
+    public string? OriginalName { get; init; }
+}
+
+

--- a/GardenAI.Application/Entity/Dtos/EntityDto.cs
+++ b/GardenAI.Application/Entity/Dtos/EntityDto.cs
@@ -1,0 +1,5 @@
+﻿namespace GardenAI.Application.Entity.Dtos;
+
+/// <summary>Read model for a synced Home Assistant entity.</summary>
+public sealed record EntityDto(string Id, string? DeviceId, string? AreaId, string Platform, string Name);
+

--- a/GardenAI.Infrastructure.HomeAssistant/Common/Contracts/HaEventTypes.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Common/Contracts/HaEventTypes.cs
@@ -1,0 +1,10 @@
+﻿namespace GardenAI.Infrastructure.HomeAssistant.Common.Contracts;
+
+/// <summary>Known Home Assistant registry event type names.</summary>
+public static class HaEventTypes
+{
+    public const string AreaRegistryUpdated = "area_registry_updated";
+    public const string DeviceRegistryUpdated = "device_registry_updated";
+    public const string EntityRegistryUpdated = "entity_registry_updated";
+}
+

--- a/GardenAI.Infrastructure.HomeAssistant/Common/Exceptions/HomeAssistantApiException.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Common/Exceptions/HomeAssistantApiException.cs
@@ -1,0 +1,16 @@
+﻿namespace GardenAI.Infrastructure.HomeAssistant.Common.Exceptions;
+
+/// <summary>Represents failures when communicating with the Home Assistant API.</summary>
+public sealed class HomeAssistantApiException : Exception
+{
+    public HomeAssistantApiException(string message)
+        : base(message)
+    {
+    }
+
+    public HomeAssistantApiException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+

--- a/GardenAI.Infrastructure.HomeAssistant/Events/Handlers/AreaRegistryEventHandler.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Events/Handlers/AreaRegistryEventHandler.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.Json;
+using GardenAI.Application.Area.Commands;
+using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Contracts;
+using GardenAI.Application.Dispatching.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.Events.Handlers;
+
+/// <summary>Handles area_registry_updated events from Home Assistant.</summary>
+public sealed class AreaRegistryEventHandler : IRegistryEventHandler
+{
+    private readonly ICommandDispatcher _dispatcher;
+    private readonly ILogger<AreaRegistryEventHandler> _logger;
+
+    public AreaRegistryEventHandler(
+        ICommandDispatcher dispatcher,
+        ILogger<AreaRegistryEventHandler> logger)
+    {
+        _dispatcher = dispatcher;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(HaRegistryEvent evt, CancellationToken ct = default)
+    {
+        var data = evt.Data.Deserialize<HaAreaRegistryEventData>();
+        if (data is null)
+        {
+            _logger.LogWarning("Skipping malformed area registry event");
+            return;
+        }
+
+        if (string.Equals(data.Action, "create", StringComparison.Ordinal)
+            || string.Equals(data.Action, "update", StringComparison.Ordinal))
+        {
+            await _dispatcher.DispatchAsync(
+                new UpsertAreaCommand(data.AreaId, data.AreaId, null, null),
+                ct).ConfigureAwait(false);
+            return;
+        }
+
+        _logger.LogInformation("Area remove event received for {AreaId}; delete command not wired yet", data.AreaId);
+    }
+}

--- a/GardenAI.Infrastructure.HomeAssistant/Events/Handlers/DeviceRegistryEventHandler.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Events/Handlers/DeviceRegistryEventHandler.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.Json;
+using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Contracts;
+using GardenAI.Application.Device.Commands;
+using GardenAI.Application.Dispatching.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.Events.Handlers;
+
+/// <summary>Handles device_registry_updated events from Home Assistant.</summary>
+public sealed class DeviceRegistryEventHandler : IRegistryEventHandler
+{
+    private readonly ICommandDispatcher _dispatcher;
+    private readonly ILogger<DeviceRegistryEventHandler> _logger;
+
+    public DeviceRegistryEventHandler(
+        ICommandDispatcher dispatcher,
+        ILogger<DeviceRegistryEventHandler> logger)
+    {
+        _dispatcher = dispatcher;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(HaRegistryEvent evt, CancellationToken ct = default)
+    {
+        var data = evt.Data.Deserialize<HaDeviceRegistryEventData>();
+        if (data is null)
+        {
+            _logger.LogWarning("Skipping malformed device registry event");
+            return;
+        }
+
+        if (string.Equals(data.Action, "create", StringComparison.Ordinal)
+            || string.Equals(data.Action, "update", StringComparison.Ordinal))
+        {
+            await _dispatcher.DispatchAsync(
+                new UpsertDeviceCommand(data.DeviceId, data.AreaId, data.DeviceId, null, null, null),
+                ct).ConfigureAwait(false);
+            return;
+        }
+
+        _logger.LogInformation("Device remove event received for {DeviceId}; delete command not wired yet", data.DeviceId);
+    }
+}

--- a/GardenAI.Infrastructure.HomeAssistant/Events/Handlers/EntityRegistryEventHandler.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Events/Handlers/EntityRegistryEventHandler.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.Json;
+using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.Events.Handlers;
+
+/// <summary>Handles entity_registry_updated events from Home Assistant.</summary>
+public sealed class EntityRegistryEventHandler : IRegistryEventHandler
+{
+    private readonly ILogger<EntityRegistryEventHandler> _logger;
+
+    public EntityRegistryEventHandler(ILogger<EntityRegistryEventHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task HandleAsync(HaRegistryEvent evt, CancellationToken ct = default)
+    {
+        var data = evt.Data.Deserialize<HaEntityRegistryEventData>();
+        if (data is null)
+        {
+            _logger.LogWarning("Skipping malformed entity registry event");
+            return Task.CompletedTask;
+        }
+
+        _logger.LogInformation(
+            "Entity registry event received: action={Action}, entityId={EntityId}",
+            data.Action,
+            data.EntityId);
+
+        return Task.CompletedTask;
+    }
+}

--- a/GardenAI.Infrastructure.HomeAssistant/GardenAI.Infrastructure.HomeAssistant.csproj
+++ b/GardenAI.Infrastructure.HomeAssistant/GardenAI.Infrastructure.HomeAssistant.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\GardenAI.Application\GardenAI.Application.csproj" />
+    <ProjectReference Include="..\GardenAI.Domain\GardenAI.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/GardenAI.Infrastructure.HomeAssistant/Rest/Clients/HomeAssistantRestClient.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Rest/Clients/HomeAssistantRestClient.cs
@@ -1,0 +1,75 @@
+﻿using System.Net.Http.Headers;
+using System.Text.Json;
+using GardenAI.Application.Area.Contracts;
+using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Configuration;
+using GardenAI.Application.Device.Contracts;
+using GardenAI.Application.Entity.Contracts;
+using GardenAI.Infrastructure.HomeAssistant.Common.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.Rest.Clients;
+
+/// <summary>HTTP client for Home Assistant registry endpoints.</summary>
+public sealed class HomeAssistantRestClient : IHomeAssistantRestClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly HomeAssistantOptions _options;
+    private readonly ILogger<HomeAssistantRestClient> _logger;
+
+    public HomeAssistantRestClient(
+        HttpClient httpClient,
+        HomeAssistantOptions options,
+        ILogger<HomeAssistantRestClient> logger)
+    {
+        _httpClient = httpClient;
+        _options = options;
+        _logger = logger;
+    }
+
+    public Task<IReadOnlyList<HaAreaDto>> GetAreasAsync(CancellationToken ct = default)
+        => GetListAsync<HaAreaDto>("api/config/area_registry/list", ct);
+
+    public Task<IReadOnlyList<HaDeviceDto>> GetDevicesAsync(CancellationToken ct = default)
+        => GetListAsync<HaDeviceDto>("api/config/device_registry/list", ct);
+
+    public Task<IReadOnlyList<HaEntityDto>> GetEntitiesAsync(CancellationToken ct = default)
+        => GetListAsync<HaEntityDto>("api/config/entity_registry/list", ct);
+
+    private async Task<IReadOnlyList<T>> GetListAsync<T>(string relativePath, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, relativePath);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.AccessToken);
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            var payload = await JsonSerializer.DeserializeAsync<List<T>>(stream, JsonOptions, ct).ConfigureAwait(false)
+                ?? new List<T>();
+
+            _logger.LogInformation(
+                "Fetched {Count} items from Home Assistant endpoint {Path}",
+                payload.Count,
+                relativePath);
+
+            return payload;
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new HomeAssistantApiException($"Home Assistant request failed for '{relativePath}'.", ex);
+        }
+        catch (TaskCanceledException ex)
+        {
+            throw new HomeAssistantApiException($"Home Assistant request timed out for '{relativePath}'.", ex);
+        }
+    }
+}
+

--- a/GardenAI.Infrastructure.HomeAssistant/Sync/Services/HomeAssistantSyncBackgroundService.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Sync/Services/HomeAssistantSyncBackgroundService.cs
@@ -1,0 +1,88 @@
+﻿using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.Sync.Services;
+
+/// <summary>Background service that owns HA connection lifecycle and event processing loop.</summary>
+public sealed class HomeAssistantSyncBackgroundService : BackgroundService
+{
+    private readonly IHomeAssistantWebSocketClient _webSocketClient;
+    private readonly ISyncOrchestrator _syncOrchestrator;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly HomeAssistantOptions _options;
+    private readonly ILogger<HomeAssistantSyncBackgroundService> _logger;
+
+    public HomeAssistantSyncBackgroundService(
+        IHomeAssistantWebSocketClient webSocketClient,
+        ISyncOrchestrator syncOrchestrator,
+        IServiceScopeFactory scopeFactory,
+        HomeAssistantOptions options,
+        ILogger<HomeAssistantSyncBackgroundService> logger)
+    {
+        _webSocketClient = webSocketClient;
+        _syncOrchestrator = syncOrchestrator;
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("HomeAssistant sync background service started");
+
+        var attempts = 0;
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _webSocketClient.ConnectAsync(stoppingToken).ConfigureAwait(false);
+                await _syncOrchestrator.RunInitialSyncAsync(stoppingToken).ConfigureAwait(false);
+
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    var evt = await _webSocketClient.ReadNextEventAsync(stoppingToken).ConfigureAwait(false);
+                    if (evt is null)
+                    {
+                        break;
+                    }
+
+                    await using var scope = _scopeFactory.CreateAsyncScope();
+                    var handler = scope.ServiceProvider.GetRequiredKeyedService<IRegistryEventHandler>(evt.EventType);
+                    await handler.HandleAsync(evt, stoppingToken).ConfigureAwait(false);
+                }
+
+                attempts = 0;
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                attempts++;
+                if (attempts > _options.ReconnectMaxRetries)
+                {
+                    _logger.LogError(ex, "Stopping HA sync after max reconnect attempts: {Attempts}", attempts);
+                    break;
+                }
+
+                var delay = ComputeBackoff(attempts);
+                _logger.LogWarning(ex, "HA sync reconnect attempt {Attempt}. Waiting {Delay}", attempts, delay);
+                await Task.Delay(delay, stoppingToken).ConfigureAwait(false);
+            }
+        }
+
+        await _webSocketClient.DisconnectAsync(stoppingToken).ConfigureAwait(false);
+        _logger.LogInformation("HomeAssistant sync background service stopped");
+    }
+
+    private static TimeSpan ComputeBackoff(int attempt)
+    {
+        var seconds = Math.Min(60, (int)Math.Pow(2, Math.Min(attempt, 5)));
+        return TimeSpan.FromSeconds(seconds);
+    }
+}
+

--- a/GardenAI.Infrastructure.HomeAssistant/Sync/Services/SyncOrchestrator.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/Sync/Services/SyncOrchestrator.cs
@@ -1,0 +1,53 @@
+﻿using GardenAI.Application.Common.Sync.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.Sync.Services;
+
+/// <summary>Coordinates initial sync ordering for Home Assistant registry data.</summary>
+public sealed class SyncOrchestrator : ISyncOrchestrator
+{
+    private readonly IHomeAssistantRestClient _restClient;
+    private readonly ILogger<SyncOrchestrator> _logger;
+    private readonly SemaphoreSlim _syncLock = new(1, 1);
+
+    public SyncState State { get; private set; } = SyncState.Unsynced;
+
+    public SyncOrchestrator(
+        IHomeAssistantRestClient restClient,
+        ILogger<SyncOrchestrator> logger)
+    {
+        _restClient = restClient;
+        _logger = logger;
+    }
+
+    public async Task RunInitialSyncAsync(CancellationToken ct = default)
+    {
+        await _syncLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            State = SyncState.Syncing;
+
+            var areas = await _restClient.GetAreasAsync(ct).ConfigureAwait(false);
+            var devices = await _restClient.GetDevicesAsync(ct).ConfigureAwait(false);
+            var entities = await _restClient.GetEntitiesAsync(ct).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Initial Home Assistant fetch completed: areas={AreaCount}, devices={DeviceCount}, entities={EntityCount}",
+                areas.Count,
+                devices.Count,
+                entities.Count);
+
+            State = SyncState.Synced;
+        }
+        catch
+        {
+            State = SyncState.Error;
+            throw;
+        }
+        finally
+        {
+            _syncLock.Release();
+        }
+    }
+}
+

--- a/GardenAI.Infrastructure.HomeAssistant/WebSockets/Services/HomeAssistantWebSocketClient.cs
+++ b/GardenAI.Infrastructure.HomeAssistant/WebSockets/Services/HomeAssistantWebSocketClient.cs
@@ -1,0 +1,200 @@
+﻿using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Configuration;
+using GardenAI.Application.Common.Sync.Contracts;
+using Microsoft.Extensions.Logging;
+
+namespace GardenAI.Infrastructure.HomeAssistant.WebSockets.Services;
+
+/// <summary>WebSocket client for Home Assistant realtime events.</summary>
+public sealed class HomeAssistantWebSocketClient : IHomeAssistantWebSocketClient, IDisposable
+{
+    private readonly HomeAssistantOptions _options;
+    private readonly ILogger<HomeAssistantWebSocketClient> _logger;
+    private readonly Channel<HaRegistryEvent> _eventChannel;
+    private readonly ClientWebSocket _socket = new();
+    private readonly CancellationTokenSource _receiveCts = new();
+
+    private int _messageId;
+    private Task? _receiveTask;
+
+    public HomeAssistantWebSocketClient(
+        HomeAssistantOptions options,
+        ILogger<HomeAssistantWebSocketClient> logger)
+    {
+        _options = options;
+        _logger = logger;
+        _eventChannel = Channel.CreateBounded<HaRegistryEvent>(
+            new BoundedChannelOptions(1000)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = false,
+                SingleWriter = true
+            });
+    }
+
+    public async Task ConnectAsync(CancellationToken ct = default)
+    {
+        if (_socket.State == WebSocketState.Open)
+        {
+            return;
+        }
+
+        var wsUri = BuildWebSocketUri(_options.BaseUrl);
+        _logger.LogInformation("Connecting to Home Assistant websocket at {Uri}", wsUri);
+
+        await _socket.ConnectAsync(wsUri, ct).ConfigureAwait(false);
+        _receiveTask = Task.Run(() => ReceiveLoopAsync(_receiveCts.Token), CancellationToken.None);
+    }
+
+    public async Task DisconnectAsync(CancellationToken ct = default)
+    {
+        if (_socket.State == WebSocketState.Open)
+        {
+            await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Shutdown", ct).ConfigureAwait(false);
+        }
+
+        _receiveCts.Cancel();
+
+        if (_receiveTask is not null)
+        {
+            await _receiveTask.ConfigureAwait(false);
+        }
+    }
+
+    public async Task<int> SendAsync<T>(T message, CancellationToken ct = default)
+    {
+        var id = Interlocked.Increment(ref _messageId);
+        var payload = JsonSerializer.Serialize(message);
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await _socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+        return id;
+    }
+
+    public Task SubscribeToEventAsync(string eventType, CancellationToken ct = default)
+    {
+        var message = new
+        {
+            id = Interlocked.Increment(ref _messageId),
+            type = "subscribe_events",
+            event_type = eventType
+        };
+        return SendTextAsync(JsonSerializer.Serialize(message), ct);
+    }
+
+    public Task UnsubscribeFromEventAsync(string eventType, CancellationToken ct = default)
+    {
+        var message = new
+        {
+            id = Interlocked.Increment(ref _messageId),
+            type = "unsubscribe_events",
+            event_type = eventType
+        };
+        return SendTextAsync(JsonSerializer.Serialize(message), ct);
+    }
+
+    public async Task<HaRegistryEvent?> ReadNextEventAsync(CancellationToken ct = default)
+    {
+        if (await _eventChannel.Reader.WaitToReadAsync(ct).ConfigureAwait(false)
+            && _eventChannel.Reader.TryRead(out var evt))
+        {
+            return evt;
+        }
+
+        return null;
+    }
+
+    private async Task SendTextAsync(string payload, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await _socket.SendAsync(bytes, WebSocketMessageType.Text, true, ct).ConfigureAwait(false);
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken ct)
+    {
+        var buffer = new byte[8 * 1024];
+
+        while (!ct.IsCancellationRequested && _socket.State == WebSocketState.Open)
+        {
+            using var ms = new MemoryStream();
+            WebSocketReceiveResult result;
+
+            do
+            {
+                result = await _socket.ReceiveAsync(buffer, ct).ConfigureAwait(false);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    return;
+                }
+
+                ms.Write(buffer, 0, result.Count);
+            }
+            while (!result.EndOfMessage);
+
+            var payload = Encoding.UTF8.GetString(ms.ToArray());
+            TryPublishEvent(payload);
+        }
+    }
+
+    private void TryPublishEvent(string payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            var root = document.RootElement;
+
+            if (!root.TryGetProperty("type", out var typeElement)
+                || !string.Equals(typeElement.GetString(), "event", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var eventElement = root.GetProperty("event");
+            var eventType = eventElement.GetProperty("event_type").GetString();
+            if (string.IsNullOrWhiteSpace(eventType))
+            {
+                return;
+            }
+
+            var data = eventElement.TryGetProperty("data", out var dataElement)
+                ? dataElement.Clone()
+                : default;
+
+            _eventChannel.Writer.TryWrite(new HaRegistryEvent
+            {
+                EventType = eventType,
+                Data = data
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse websocket payload from Home Assistant");
+        }
+    }
+
+    private static Uri BuildWebSocketUri(string baseUrl)
+    {
+        var normalized = baseUrl.TrimEnd('/');
+        if (normalized.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = "wss://" + normalized.Substring("https://".Length);
+        }
+        else if (normalized.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = "ws://" + normalized.Substring("http://".Length);
+        }
+
+        return new Uri($"{normalized}/api/websocket", UriKind.Absolute);
+    }
+
+    public void Dispose()
+    {
+        _receiveCts.Cancel();
+        _socket.Dispose();
+        _receiveCts.Dispose();
+    }
+}
+

--- a/GardenAI.Presentation/GardenAI.Presentation.csproj
+++ b/GardenAI.Presentation/GardenAI.Presentation.csproj
@@ -16,6 +16,7 @@
       <ProjectReference Include="..\GardenAI.Infrastructure.Persistence\GardenAI.Infrastructure.Persistence.csproj" />
       <ProjectReference Include="..\GardenAI.Infrastructure.Messaging\GardenAI.Infrastructure.Messaging.csproj" />
       <ProjectReference Include="..\GardenAI.Integrations.OpenMeteo\GardenAI.Integrations.OpenMeteo.csproj" />
+      <ProjectReference Include="..\GardenAI.Infrastructure.HomeAssistant\GardenAI.Infrastructure.HomeAssistant.csproj" />
     </ItemGroup>
 
 </Project>

--- a/GardenAI.Presentation/Program.cs
+++ b/GardenAI.Presentation/Program.cs
@@ -1,17 +1,25 @@
+using GardenAI.Application.Common.Sync.Abstractions;
+using GardenAI.Application.Common.Sync.Configuration;
 using GardenAI.Application.Weather.Abstractions;
 using GardenAI.Application.Weather.Configuration;
 using GardenAI.Domain.Assistant.Abstractions;
 using GardenAI.Domain.Common.Abstractions;
+using GardenAI.Infrastructure.HomeAssistant.Common.Contracts;
+using GardenAI.Infrastructure.HomeAssistant.Events.Handlers;
+using GardenAI.Infrastructure.HomeAssistant.Rest.Clients;
+using GardenAI.Infrastructure.HomeAssistant.Sync.Services;
+using GardenAI.Infrastructure.HomeAssistant.WebSockets.Services;
 using GardenAI.Infrastructure.Messaging;
 using GardenAI.Infrastructure.Persistence.Assistant.Repositories;
 using GardenAI.Infrastructure.Persistence.Database;
 using GardenAI.Integrations.OpenMeteo.Forecast.Clients;
-using Microsoft.EntityFrameworkCore;
 using GardenAI.Presentation.Configuration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// ── Register Services ──────────────────────────────────────────────────────
+// Register Services
 builder.Services.AddOpenApi();
 
 // Persistence
@@ -32,12 +40,32 @@ builder.Services.AddHttpClient<IOpenMeteoForecastClient, OpenMeteoForecastClient
     client.Timeout = TimeSpan.FromSeconds(20);
 });
 
+// Home Assistant sync options and services
+var homeAssistantOptions = new HomeAssistantOptions();
+builder.Configuration.GetSection(HomeAssistantOptions.SectionName).Bind(homeAssistantOptions);
+builder.Services.AddSingleton(homeAssistantOptions);
+
+builder.Services.AddSingleton<IHomeAssistantWebSocketClient, HomeAssistantWebSocketClient>();
+builder.Services.AddHttpClient<IHomeAssistantRestClient, HomeAssistantRestClient>((sp, client) =>
+{
+    var options = sp.GetRequiredService<HomeAssistantOptions>();
+    client.BaseAddress = new Uri(options.BaseUrl, UriKind.Absolute);
+    client.Timeout = TimeSpan.FromSeconds(30);
+});
+builder.Services.AddSingleton<ISyncOrchestrator, SyncOrchestrator>();
+
+builder.Services.AddKeyedScoped<IRegistryEventHandler, AreaRegistryEventHandler>(HaEventTypes.AreaRegistryUpdated);
+builder.Services.AddKeyedScoped<IRegistryEventHandler, DeviceRegistryEventHandler>(HaEventTypes.DeviceRegistryUpdated);
+builder.Services.AddKeyedScoped<IRegistryEventHandler, EntityRegistryEventHandler>(HaEventTypes.EntityRegistryUpdated);
+
+builder.Services.AddHostedService<HomeAssistantSyncBackgroundService>();
+
 builder.Services.AddCqrsServices(builder.Configuration);
 builder.Services.AddExternalClients(builder.Configuration);
 
 var app = builder.Build();
 
-// ── Initialize and Configure Application ───────────────────────────────────
+// Initialize and Configure Application
 await app.ConfigureMiddlewareAsync();
 app.ConfigurePipeline();
 app.MapRoutes();

--- a/GardenAI.Presentation/appsettings.json
+++ b/GardenAI.Presentation/appsettings.json
@@ -60,6 +60,12 @@
       "pot-6": "00000000-0000-0000-0000-000000000006"
     }
   },
+  "HomeAssistant": {
+    "BaseUrl": "http://homeassistant.local:8123/",
+    "AccessToken": "",
+    "PingIntervalSeconds": 30,
+    "ReconnectMaxRetries": 10
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=GardenAI;Username=ha_user;Password="
   }

--- a/GardenAI.sln
+++ b/GardenAI.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GardenAI.Integrations.OpenM
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GardenAI.Infrastructure.Messaging", "GardenAI.Infrastructure.Messaging\GardenAI.Infrastructure.Messaging.csproj", "{8C7E9F42-C3B8-4D2E-9A5F-1E8B2C3D4A5F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GardenAI.Infrastructure.HomeAssistant", "GardenAI.Infrastructure.HomeAssistant\GardenAI.Infrastructure.HomeAssistant.csproj", "{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,18 @@ Global
 		{8C7E9F42-C3B8-4D2E-9A5F-1E8B2C3D4A5F}.Release|x64.Build.0 = Release|Any CPU
 		{8C7E9F42-C3B8-4D2E-9A5F-1E8B2C3D4A5F}.Release|x86.ActiveCfg = Release|Any CPU
 		{8C7E9F42-C3B8-4D2E-9A5F-1E8B2C3D4A5F}.Release|x86.Build.0 = Release|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Debug|x64.Build.0 = Debug|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Debug|x86.Build.0 = Debug|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Release|x64.ActiveCfg = Release|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Release|x64.Build.0 = Release|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{AB448B0E-B5CB-487D-8B41-3E1DEF7948C3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Closes #69
## What changed
- added new GardenAI.Infrastructure.HomeAssistant project and wired it into GardenAI.sln
- referenced new project from GardenAI.Presentation/GardenAI.Presentation.csproj
- added Home Assistant sync scaffolding:
  - websocket client
  - REST client
  - initial sync orchestrator
  - background service loop
  - keyed registry event handlers
- bound HomeAssistant options in GardenAI.Presentation/Program.cs
- added HomeAssistant section in GardenAI.Presentation/appsettings.json
- populated GardenAI.Presentation/appsettings.Development.json.example
- reorganized application contracts/abstractions into domain-first folders (Area, Device, Entity, Common/Sync)
## Verification
- dotnet build GardenAI.sln succeeds locally